### PR TITLE
Set session store path

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,6 +208,9 @@ func main() {
 
 	// Initialize session store
 	store := cookie.NewStore([]byte("secret"))
+	store.Options(sessions.Options{
+		Path: "/",
+	})
 	r.Use(sessions.Sessions("isley_session", store))
 
 	// Public routes


### PR DESCRIPTION
Configured the session store to use the root path by adding the appropriate option. This ensures cookies are accessible across the entire application.

This resolves #48 