### PR TITLE
Add active state handling for navigation links

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,8 +70,15 @@ func main() {
 	// Set up Gin router
 	r := gin.Default()
 
+	// inject currentPath into the context
+	r.Use(func(c *gin.Context) {
+		c.Set("currentPath", c.Request.URL.Path)
+		c.Next()
+	})
+
 	funcMap := template.FuncMap{
-		"upper": strings.ToUpper, // Define the 'upper' function
+		"upper":     strings.ToUpper, // Define the 'upper' function
+		"hasPrefix": strings.HasPrefix,
 		"default": func(val interface{}, def string) string {
 			if str, ok := val.(string); ok && str != "" {
 				return str
@@ -296,7 +303,6 @@ func handleHealth(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 	})
-	c.String(http.StatusOK, "Isley is running")
 	logger.Log.Info("Health check passed")
 }
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -13,8 +13,10 @@ func AddBasicRoutes(r *gin.RouterGroup, version string) {
 	r.GET("/", func(c *gin.Context) {
 		lang := utils.GetLanguage(c)
 		translations := utils.TranslationService.GetTranslations(lang)
+		currentPath, _ := c.Get("currentPath")
 		c.HTML(http.StatusOK, "views/index.html", gin.H{
 			"title":           "Dashboard",
+			"currentPath":     currentPath,
 			"version":         version,
 			"plants":          handlers.GetLivingPlants(),
 			"activities":      config.Activities,
@@ -28,8 +30,10 @@ func AddBasicRoutes(r *gin.RouterGroup, version string) {
 	r.GET("/plants", func(c *gin.Context) {
 		lang := utils.GetLanguage(c)
 		translations := utils.TranslationService.GetTranslations(lang)
+		currentPath, _ := c.Get("currentPath")
 		c.HTML(http.StatusOK, "views/plants.html", gin.H{
 			"title":           "Plants",
+			"currentPath":     currentPath,
 			"version":         version,
 			"zones":           config.Zones,
 			"strains":         config.Strains,
@@ -47,8 +51,10 @@ func AddBasicRoutes(r *gin.RouterGroup, version string) {
 	r.GET("/strains", func(c *gin.Context) {
 		lang := utils.GetLanguage(c)
 		translations := utils.TranslationService.GetTranslations(lang)
+		currentPath, _ := c.Get("currentPath")
 		c.HTML(http.StatusOK, "views/strains.html", gin.H{
 			"title":           "Strains",
+			"currentPath":     currentPath,
 			"version":         version,
 			"strains":         config.Strains,
 			"breeders":        config.Breeders,
@@ -64,8 +70,10 @@ func AddBasicRoutes(r *gin.RouterGroup, version string) {
 	r.GET("/graph/:id", func(c *gin.Context) {
 		lang := utils.GetLanguage(c)
 		translations := utils.TranslationService.GetTranslations(lang)
+		currentPath, _ := c.Get("currentPath")
 		c.HTML(http.StatusOK, "views/graph.html", gin.H{
 			"title":           "Sensor Graphs",
+			"currentPath":     currentPath,
 			"version":         version,
 			"SensorID":        c.Param("id"),
 			"plants":          handlers.GetLivingPlants(),
@@ -80,8 +88,10 @@ func AddBasicRoutes(r *gin.RouterGroup, version string) {
 	r.GET("/plant/:id", func(c *gin.Context) {
 		lang := utils.GetLanguage(c)
 		translations := utils.TranslationService.GetTranslations(lang)
+		currentPath, _ := c.Get("currentPath")
 		c.HTML(http.StatusOK, "views/plant.html", gin.H{
 			"title":           "Plant Details",
+			"currentPath":     currentPath,
 			"version":         version,
 			"plant":           handlers.GetPlant(c.Param("id")),
 			"zones":           config.Zones,
@@ -102,8 +112,10 @@ func AddBasicRoutes(r *gin.RouterGroup, version string) {
 	r.GET("/strain/:id", func(c *gin.Context) {
 		lang := utils.GetLanguage(c)
 		translations := utils.TranslationService.GetTranslations(lang)
+		currentPath, _ := c.Get("currentPath")
 		c.HTML(http.StatusOK, "views/strain.html", gin.H{
 			"title":           "Strain Details",
+			"currentPath":     currentPath,
 			"version":         version,
 			"strain":          handlers.GetStrain(c.Param("id")),
 			"breeders":        config.Breeders,
@@ -188,8 +200,10 @@ func AddProtectedRotues(r *gin.RouterGroup, version string) {
 	r.GET("/settings", func(c *gin.Context) {
 		lang := utils.GetLanguage(c)
 		translations := utils.TranslationService.GetTranslations(lang)
+		currentPath, _ := c.Get("currentPath")
 		c.HTML(http.StatusOK, "views/settings.html", gin.H{
 			"title":           "Settings",
+			"currentPath":     currentPath,
 			"version":         version,
 			"settings":        handlers.GetSettings(),
 			"zones":           config.Zones,
@@ -208,8 +222,10 @@ func AddProtectedRotues(r *gin.RouterGroup, version string) {
 	r.GET("/sensors", func(c *gin.Context) {
 		lang := utils.GetLanguage(c)
 		translations := utils.TranslationService.GetTranslations(lang)
+		currentPath, _ := c.Get("currentPath")
 		c.HTML(http.StatusOK, "views/sensors.html", gin.H{
 			"title":           "Sensors",
+			"currentPath":     currentPath,
 			"version":         version,
 			"settings":        handlers.GetSettings(),
 			"sensors":         handlers.GetSensors(),

--- a/web/static/css/isley.css
+++ b/web/static/css/isley.css
@@ -1,3 +1,16 @@
+/* Bootstrap Overrides */
+header {
+    .nav-item {
+        width:40px;
+        height: 38px;
+        margin-right: 10px;
+    }
+
+    .nav-link {
+        padding: 7px 12px;
+    }
+}
+
 /* Dark Mode Styling */
 body {
     background-color: #121212;

--- a/web/templates/common/header2.html
+++ b/web/templates/common/header2.html
@@ -20,34 +20,34 @@
         </li>
         {{ end }}
         <li class="nav-item">
-            <a href="/plants" class="nav-link" aria-label="{{ .lcl.title_plants }}">
+            <a href="/plants" class="text-center nav-link{{ if hasPrefix .currentPath "/plants" }} active{{ end }}" aria-label="{{ .lcl.title_plants }}">
                 <i class="fa fa-cannabis" title="{{ .lcl.title_plants }}"></i>
             </a>
         </li>
         <li class="nav-item">
-            <a href="/strains" class="nav-link" aria-label="{{ .lcl.title_strains }}">
+            <a href="/strains" class="text-center nav-link{{ if hasPrefix .currentPath "/strains" }} active{{ end }}" aria-label="{{ .lcl.title_strains }}">
                 <i class="fa fa-dna" title="{{ .lcl.title_strains }}"></i>
             </a>
         </li>
         {{ if .loggedIn }}
         <li class="nav-item">
-            <a href="/sensors" class="nav-link" aria-label="{{ .lcl.title_sensors }}">
+            <a href="/sensors" class="text-center nav-link{{ if hasPrefix .currentPath "/sensors" }} active{{ end }}" aria-label="{{ .lcl.title_sensors }}">
                 <i class="fa fa-thermometer-half" title="{{ .lcl.title_sensors }}"></i>
             </a>
         </li>
         <li class="nav-item">
-            <a href="/settings" class="nav-link" aria-label="{{ .lcl.title_settings }}">
+            <a href="/settings" class="text-center nav-link{{ if hasPrefix .currentPath "/settings" }} active{{ end }}" aria-label="{{ .lcl.title_settings }}">
                 <i class="fa fa-cog" title="{{ .lcl.title_settings }}"></i>
             </a>
         </li>
         <li class="nav-item">
-            <a href="/logout" class="nav-link" aria-label="{{ .lcl.title_logout }}">
+            <a href="/logout" class="text-center nav-link" aria-label="{{ .lcl.title_logout }}">
                 <i class="fa fa-sign-out" title="{{ .lcl.title_logout }}"></i>
             </a>
         </li>
         {{ else }}
         <li class="nav-item">
-            <a href="/login" class="nav-link" aria-label="{{ .lcl.title_login }}">
+            <a href="/login" class="text-center nav-link" aria-label="{{ .lcl.title_login }}">
                 <i class="fa fa-sign-in" title="{{ .lcl.title_login }}"></i>
             </a>
         </li>

--- a/web/templates/common/header2.html
+++ b/web/templates/common/header2.html
@@ -14,7 +14,7 @@
     <ul class="nav nav-pills">
         {{ if .loggedIn }}
         <li class="nav-item">
-            <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addMultiPlantActivityModal">
+            <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addMultiPlantActivityModal">
                 <i class="fa fa-plus"></i>
             </button>
         </li>


### PR DESCRIPTION
Introduced `currentPath` tracking in the context to determine the active navigation link dynamically. Updated templates, CSS, and routes to style active links and improve navigation usability.

Removed string output from /health endpoint to restore valid JSON output.

Active nav links based on page being viewed:
![image](https://github.com/user-attachments/assets/2d626ad6-4be6-4824-888f-f43c9f6ed19b)
![image](https://github.com/user-attachments/assets/26e2cab5-030d-4a69-b94d-0746d0f50721)

*note*
I haven't really coded in Go before, if this should be done differently let me know, happy to change it :)