### PR TITLE
Add theme toggle functionality and dark/light mode styles

### DIFF
--- a/web/static/css/isley.css
+++ b/web/static/css/isley.css
@@ -1,159 +1,242 @@
-/* Bootstrap Overrides */
-header {
-    .nav-item {
-        width:40px;
-        height: 38px;
-        margin-right: 10px;
-    }
+:root {
+    /* Light mode (default) */
+    --color-bg: #f8f9fa;
+    --color-fg: #212529;
+    --color-accent: #007bff;
+    --color-accent-hover: #0056b3;
+    --color-border: #ced4da;
+    --color-card: #fff;
+    --color-card-border: #dee2e6;
+    --color-muted: #6c757d;
+    --color-row-hover: #e9ecef;
+    --color-table-header: #e9ecef;
+    --color-dropdown-bg: #fff;
+    --color-dropdown-fg: #212529;
+    --color-dropdown-border: #ced4da;
+    --color-input-bg: #fff;
+    --color-input-fg: #212529;
+    --color-input-border: #ced4da;
+    --color-input-focus-border: #007bff;
+    --color-btn-secondary-bg: #e9ecef;
+    --color-btn-secondary-fg: #212529;
+    --color-btn-secondary-border: #ced4da;
+    --color-btn-secondary-hover-bg: #dee2e6;
+    --color-view-btn-border: #ced4da;
+    --color-view-btn-hover-bg: #e9ecef;
+    --color-view-btn-hover-fg: #495057;
+    --color-view-btn-active-bg: #0d6efd;
+    --color-view-btn-active-fg: #fff;
+    --color-view-btn-active-border: #0d6efd;
+    --color-table-bg: #fff;
+    --color-table-th: #e9ecef;
+    --color-spinner-overlay: rgba(0, 0, 0, 0.5);
 
-    .nav-link {
-        padding: 7px 12px;
-    }
+    /* Component-specific - feel free to add/adjust for your app */
+    --color-dropdown-menu-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+    --color-thumb-hover: #e9ecef;
+    --color-success-bg: #d4edda;
 }
 
-/* Dark Mode Styling */
+body.dark-mode {
+    --color-bg: #121212;
+    --color-fg: #ffffff;
+    --color-accent: #007bff;
+    --color-accent-hover: #63a4d4;
+    --color-border: #333;
+    --color-card: #212529;
+    --color-card-border: #333;
+    --color-muted: #aaaaaa;
+    --color-row-hover: #222232;
+    --color-table-header: #2e2e2e;
+    --color-dropdown-bg: #1e1e1e;
+    --color-dropdown-fg: #fff;
+    --color-dropdown-border: #333;
+    --color-input-bg: #2e2e2e;
+    --color-input-fg: #fff;
+    --color-input-border: #555;
+    --color-input-focus-border: #90cdf4;
+    --color-btn-secondary-bg: #333;
+    --color-btn-secondary-fg: #fff;
+    --color-btn-secondary-border: #555;
+    --color-btn-secondary-hover-bg: #444;
+    --color-view-btn-border: #333;
+    --color-view-btn-hover-bg: #444;
+    --color-view-btn-hover-fg: #fff;
+    --color-view-btn-active-bg: #0d6efd;
+    --color-view-btn-active-fg: #ffffff;
+    --color-view-btn-active-border: #0d6efd;
+    --color-table-bg: #1e1e1e;
+    --color-table-th: #212529;
+    --color-spinner-overlay: rgba(0,0,0,0.85);
+
+    --color-dropdown-menu-shadow: 0px 4px 6px rgba(0,0,0,0.3);
+    --color-thumb-hover: #333;
+    --color-success-bg: #267f2f;
+}
+
+/*  GENERAL BODY/TEXT/BACKGROUND */
 body {
-    background-color: #121212;
-    color: #ffffff;
+    background-color: var(--color-bg);
+    color: var(--color-fg);
 }
-/*
-.container {
-    max-width: 400px;
-    margin-top: 50px;
+
+header .nav-item {
+    width: 40px;
+    height: 38px;
+    margin-right: 10px;
 }
- */
+header .nav-link {
+    padding: 7px 12px;
+}
+header #languageDropdown {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+/* Cards and containers */
 .card {
     padding: 20px;
+    background: var(--color-card);
+    color: var(--color-fg);
+    border: 1px solid var(--color-card-border);
 }
 
-
+/* ROWS, HOVER, TABLES */
 .clickable-row {
     cursor: pointer;
 }
+.clickable-row:hover {
+    background-color: var(--color-row-hover);
+}
+.table {
+    background-color: var(--color-table-bg);
+    border-color: var(--color-border);
+    color: var(--color-fg);
+}
+.table thead, .table .table-dark, .table-dark th {
+    background-color: var(--color-table-th);
+    color: var(--color-fg);
+}
+
+th, td {
+    color: var(--color-fg);
+}
+
+/* Responsive Images */
 @media (max-width: 768px) {
     .mb-3 img {
         margin-bottom: 1rem;
     }
 }
+
+/* VIDEO.JS OVERRIDES */
 .video-js {
-    border-radius: 0.375rem; /* Match rounded corners */
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Subtle shadow */
-}
-.centered-video {
-    display: flex;
-    justify-content: center;
+    border-radius: 0.375rem;
+    box-shadow: var(--color-dropdown-menu-shadow);
 }
 
-.graph-container {
-    height: 500px;
-    background-color: #1e1e1e;
-    border: 1px solid #333;
-    border-radius: 8px;
-    padding: 15px;
-}
-.controls {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-}
+/* COMPONENTS: DROPDOWN */
 .dropdown {
     position: relative;
 }
 .dropdown-menu {
     display: none;
     position: absolute;
-    background: #1e1e1e;
-    border: 1px solid #333;
-    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.3);
+    background: var(--color-dropdown-bg);
+    border: 1px solid var(--color-dropdown-border);
+    box-shadow: var(--color-dropdown-menu-shadow);
     padding: 10px;
     z-index: 10;
-    color: #fff;
+    color: var(--color-dropdown-fg);
 }
-
 .dropdown.open .dropdown-menu {
     display: block;
 }
-
 .dropdown-button {
     cursor: pointer;
-    background: #007bff;
-    color: white;
+    background: var(--color-accent);
+    color: #fff;
     padding: 10px 15px;
     border: none;
     border-radius: 5px;
     display: inline-flex;
     align-items: center;
 }
-
 .dropdown-button i {
     margin-left: 5px;
 }
 
+/* BUTTONS */
 .btn-outline-primary {
-    color: #007bff;
-    border-color: #007bff;
+    color: var(--color-accent);
+    border-color: var(--color-accent);
 }
-
 .btn-outline-primary:hover {
-    background-color: #007bff;
-    color: white;
+    background-color: var(--color-accent);
+    color: #fff;
+}
+.btn-secondary {
+    background-color: var(--color-btn-secondary-bg);
+    color: var(--color-btn-secondary-fg);
+    border: 1px solid var(--color-btn-secondary-border);
+}
+.btn-secondary:hover {
+    background-color: var(--color-btn-secondary-hover-bg);
+    color: var(--color-btn-secondary-fg);
+}
+.btn-primary {
+    background-color: var(--color-accent);
+    border-color: var(--color-accent);
+    color: #fff;
+}
+.btn-primary:hover {
+    background-color: var(--color-accent-hover);
+    border-color: var(--color-accent-hover);
 }
 
+/* INPUTS/DATES */
 .date-picker-container {
     display: flex;
     flex-direction: column;
     gap: 10px;
 }
-
 .date-picker-container input {
     width: 100%;
-    background: #2e2e2e;
-    border: 1px solid #555;
-    color: #fff;
+    background: var(--color-input-bg);
+    border: 1px solid var(--color-input-border);
+    color: var(--color-input-fg);
 }
-
 .date-picker-container input:focus {
     outline: none;
-    border-color: #007bff;
+    border-color: var(--color-input-focus-border);
 }
 
-.btn-secondary {
-    background-color: #333;
-    color: #fff;
-    border: 1px solid #555;
+/* CUSTOM BUTTONS */
+.view-button {
+    background-color: transparent;
+    color: var(--color-muted);
+    border: 1px solid var(--color-view-btn-border);
+    transition: background-color 0.3s, color 0.3s;
+}
+.view-button:hover {
+    background-color: var(--color-view-btn-hover-bg);
+    color: var(--color-view-btn-hover-fg);
+}
+.view-button.active {
+    background-color: var(--color-view-btn-active-bg);
+    color: var(--color-view-btn-active-fg);
+    border-color: var(--color-view-btn-active-border);
 }
 
-.btn-secondary:hover {
-    background-color: #444;
-    color: #fff;
+/* MISC */
+.sortable {
+    cursor: pointer;
 }
-
-.btn-primary {
-    background-color: #007bff;
-    border-color: #007bff;
-    color: white;
+.sortable.asc::after {
+    content: " ▲";
 }
-
-.btn-primary:hover {
-    background-color: #0056b3;
-    border-color: #0056b3;
-}
-
-table, th, td {
-    color: #fff;
-}
-
-.table {
-    background-color: #1e1e1e;
-    border-color: #333;
-}
-
-.table thead {
-    background-color: #2e2e2e;
-}
-.clickable-row:hover {
-    background-color: #f8f9fa; /* Optional: Light background on hover */
+.sortable.desc::after {
+    content: " ▼";
 }
 .thumbnail-img {
     cursor: pointer;
@@ -162,31 +245,33 @@ table, th, td {
     width: 100%;
     transition: transform 0.2s;
 }
-
 .thumbnail-img:hover {
     transform: scale(1.05);
 }
+
+/* Drop Area */
 #dropArea {
     cursor: pointer;
-    background-color: #f8f9fa;
+    background-color: var(--color-bg);
     transition: background-color 0.3s;
 }
-
 #dropArea.border-success {
-    background-color: #d4edda;
+    background-color: var(--color-success-bg);
 }
+
+/* Spinner Overlay */
 .spinner-overlay {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    background: var(--color-spinner-overlay);
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 1056; /* Higher than Bootstrap's modal (1055 for modal content) */
+    z-index: 1056;
 }
+
+/* Share Options */
 #shareOptions a {
     display: inline-block;
     margin: 0.5em 0;
@@ -194,37 +279,20 @@ table, th, td {
 #shareOptions {
     text-align: center;
 }
-/* Default button styles */
-.view-button {
-    background-color: transparent;
-    color: #6c757d; /* Bootstrap secondary color */
-    border: 1px solid #ced4da;
-    transition: background-color 0.3s, color 0.3s;
+
+/* Flex controls */
+.controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
 }
 
-/* Hover effect */
-.view-button:hover {
-    background-color: #e9ecef; /* Light gray */
-    color: #495057; /* Dark gray */
-}
-
-/* Selected button styles */
-.view-button.active {
-    background-color: #0d6efd; /* Bootstrap primary color */
-    color: #ffffff; /* White text */
-    border-color: #0d6efd;
-}
-.sortable {
-    cursor: pointer;
-}
-
-.sortable.asc::after {
-    content: " ▲";
-}
-
-.sortable.desc::after {
-    content: " ▼";
-}
-.clickable-row:hover {
-    background-color: #f8f9fa; /* Optional: Light background on hover */
+/* Graph Container */
+.graph-container {
+    height: 500px;
+    background-color: var(--color-card);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 15px;
 }

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -17,14 +17,19 @@ document.addEventListener("DOMContentLoaded", () => {
 Dynamic loading of sensor data and video streams
  */
 document.addEventListener("DOMContentLoaded", async () => {
+    // Get the current Theme from storage
+    const theme = localStorage.getItem("isley-theme") || "dark";
+    const themeTextClass = theme === "dark" ? "text-light" : "text-dark";
+    const themeBgClass = theme === "dark" ? "bg-dark" : "bg-light";
+
     const sensorsOverview = document.getElementById("sensorsOverview");
 
     // Define titles for each group
     const groupTitles = {
         Other:"Environment Sensors",
-    ACIP: "AC Infinity Devices" ,
-    Soil: "EcoWitt Soil Sensors",
-};
+        ACIP: "AC Infinity Devices" ,
+        Soil: "EcoWitt Soil Sensors",
+    };
 
     // Create spinner element
     const spinner = document.createElement("div");
@@ -32,7 +37,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     spinner.setAttribute("role", "status");
     spinner.innerHTML = `<span class="visually-hidden">Loading ...</span>`;
     sensorsOverview.appendChild(spinner);
-
 
     try {
         // Fetch sensor and stream data concurrently
@@ -140,11 +144,11 @@ document.addEventListener("DOMContentLoaded", async () => {
             Object.keys(sensorGroups).forEach((group) => {
                 if (sensorGroups[group].length > 0) {
                     const groupSensorIds = sensorGroups[group].map(sensor => sensor.id).join(",");
-                    const groupHeaderLink = `<a href='/graph/${groupSensorIds}' class='text-light'>${groupTitles[group] || group}</a>`;
+                    const groupHeaderLink = `<a href='/graph/${groupSensorIds}' class='${themeTextClass}'>${groupTitles[group] || group}</a>`;
 
                     const card = `
                         <div class="col-12 col-md-4">
-                            <div class="card h-100 bg-dark text-light">
+                            <div class="card h-100 ${themeTextClass} ${themeBgClass}">
                                 <div class="card-header text-uppercase">
                                     ${groupHeaderLink}
                                 </div>

--- a/web/static/js/theme.js
+++ b/web/static/js/theme.js
@@ -1,0 +1,88 @@
+(function () {
+    const THEME_KEY = 'isley-theme';
+
+    function setTheme(theme) {
+        const htmlElement = document.body;
+        const themeIcon = document.getElementById('themeToggleIcon');
+
+        htmlElement.setAttribute('data-bs-theme', theme);
+        if (themeIcon) {
+            if (theme === 'dark') {
+                themeIcon.classList.remove('fa-sun');
+                themeIcon.classList.add('fa-moon');
+            } else {
+                themeIcon.classList.remove('fa-moon');
+                themeIcon.classList.add('fa-sun');
+            }
+        }
+
+        localStorage.setItem(THEME_KEY, theme);
+
+        if (theme === 'dark') {
+            htmlElement.classList.add('dark-mode');
+            htmlElement.classList.remove('light-mode');
+        } else {
+            htmlElement.classList.add('light-mode');
+            htmlElement.classList.remove('dark-mode');
+        }
+
+        // Update bg-dark/bg-light classes
+        const allBgElements = document.querySelectorAll('.bg-dark, .bg-light');
+        allBgElements.forEach(el => {
+            if (theme === 'dark') {
+                el.classList.add('bg-dark');
+                el.classList.remove('bg-light');
+            } else {
+                el.classList.add('bg-light');
+                el.classList.remove('bg-dark');
+            }
+        });
+
+        // Update text-dark/text-light classes
+        const allTextElements = document.querySelectorAll('.text-dark, .text-light');
+        allTextElements.forEach(el => {
+            if (theme === 'dark') {
+                el.classList.add('text-light');
+                el.classList.remove('text-dark');
+            } else {
+                el.classList.add('text-dark');
+                el.classList.remove('text-light');
+            }
+        });
+
+        // Update table-dark/table-light classes
+        const allTableElements = document.querySelectorAll('.table-dark, .table-light');
+        allTableElements.forEach(el => {
+            if (theme === 'dark') {
+                el.classList.add('table-dark');
+                el.classList.remove('table-light');
+            } else {
+                el.classList.add('table-light');
+                el.classList.remove('table-dark');
+            }
+        });
+    }
+
+    function toggleTheme() {
+        const htmlElement = document.body;
+        const currentTheme = htmlElement.getAttribute('data-bs-theme') || 'dark';
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        setTheme(newTheme);
+    }
+
+    function loadTheme() {
+        const savedTheme = localStorage.getItem(THEME_KEY);
+        const preferredTheme = savedTheme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        setTheme(preferredTheme);
+    }
+
+    // Listen for toggle action
+    document.addEventListener('DOMContentLoaded', function () {
+        const themeToggle = document.getElementById('themeToggle');
+        // Wait for the DOM to be fully loaded before accessing elements
+        loadTheme();
+        if (themeToggle) {
+            themeToggle.addEventListener('click', toggleTheme);
+        }
+    });
+})();

--- a/web/templates/common/header.html
+++ b/web/templates/common/header.html
@@ -16,4 +16,5 @@
     <!-- Custom fonts for this template -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.7.1/css/fontawesome.min.css" integrity="sha256-tTPGZ9Rj5Gno6F5FRoPuBpoW31u5ky7IVxaP5J3Ot5o=" crossorigin="anonymous">
     <link rel="stylesheet" href="/static/css/isley.css">
+    <script src="/static/js/theme.js"></script>
 {{ end }}

--- a/web/templates/common/header2.html
+++ b/web/templates/common/header2.html
@@ -2,7 +2,7 @@
 
 </head>
 
-<body>
+<body class="dark-mode" data-bs-theme="dark">
 <header class="d-flex flex-wrap justify-content-between align-items-center py-3 mb-4 border-bottom container">
     <!-- Logo and Title -->
     <a href="/" class="d-flex align-items-center text-decoration-none link-body-emphasis">
@@ -53,22 +53,28 @@
         </li>
         {{ end }}
 
-        <!-- Language Selector -->
-        <div class="dropdown">
-            <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="languageDropdown" data-bs-toggle="dropdown" aria-expanded="false">
-                <i class="fa fa-globe"></i> <span id="currentLanguage">{{ .currentLanguage | default "en" | upper }}</span>
+        <!-- Grouped Language Selector and Dark/Light Mode Toggle -->
+        <div class="btn-group ms-2" role="group" aria-label="Language and Theme">
+            <!-- Language Selector -->
+            <div class="dropdown">
+                <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="languageDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                    <i class="fa fa-globe"></i> <span id="currentLanguage">{{ .currentLanguage | default "en" | upper }}</span>
+                </button>
+                <ul class="dropdown-menu" id="languageMenu" aria-labelledby="languageDropdown">
+                    {{ range .languages }}
+                    <li>
+                        <a class="dropdown-item d-flex align-items-center lang-select" href="#" data-lang="{{ . }}">
+                            <i class="fa fa-flag me-2"></i> {{ . | upper }}
+                        </a>
+                    </li>
+                    {{ end }}
+                </ul>
+            </div>
+            <!-- Dark/Light Mode Toggle -->
+            <button id="themeToggle" class="btn btn-outline-secondary" title="Toggle dark/light mode" aria-label="Toggle dark/light mode">
+                <i id="themeToggleIcon" class="fa fa-moon"></i>
             </button>
-            <ul class="dropdown-menu" id="languageMenu" aria-labelledby="languageDropdown">
-                {{ range .languages }}
-                <li>
-                    <a class="dropdown-item d-flex align-items-center lang-select" href="#" data-lang="{{ . }}">
-                        <i class="fa fa-flag me-2"></i> {{ . | upper }}
-                    </a>
-                </li>
-                {{ end }}
-            </ul>
         </div>
-
     </ul>
 </header>
 

--- a/web/templates/views/strains.html
+++ b/web/templates/views/strains.html
@@ -74,9 +74,8 @@
         // Function to load strains from the backend
         async function fetchStrains(view) {
             const response = await fetch(`/strains/${view}`);
-            const data = await response.json();
             //console.log("Fetched strains:", data); // Debug output
-            strains = data;
+            strains = await response.json();
             renderStrainsTable(strains);
         }
 
@@ -85,12 +84,14 @@
         function renderStrainsTable(data) {
             const editStrainModal = new bootstrap.Modal(document.getElementById("editStrainModal"));
             let filteredData = filterStrains(data, searchInput.value);
+            const theme = localStorage.getItem("isley-theme") || "dark";
+            const themeTableClass = theme === "dark" ? "table-dark" : "table-light";
 
             //If filteredData is null, reset with empty map object
             if (filteredData == null) {
                 strainsContainer.innerHTML = `
         <table class="table table-striped table-bordered table-hover">
-            <thead class="table-dark">
+            <thead class="${themeTableClass}">
                 <tr>
                     <th scope="col" data-key="name" data-type="text" class="sortable ${currentSort.key === "name" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.title_strain }} <i class="fa-solid fa-sort"></i></th>
                     <th scope="col" data-key="breeder" data-type="text" class="sortable ${currentSort.key === "breeder" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.breeder }} <i class="fa-solid fa-sort"></i></th>
@@ -106,7 +107,7 @@
             } else {
                 strainsContainer.innerHTML = `
         <table class="table table-striped table-bordered table-hover">
-            <thead class="table-dark">
+            <thead class="${themeTableClass}">
                 <tr>
                     <th scope="col" data-key="name" data-type="text" class="sortable ${currentSort.key === "name" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.title_strain }} <i class="fa-solid fa-sort"></i></th>
                     <th scope="col" data-key="breeder" data-type="text" class="sortable ${currentSort.key === "breeder" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.breeder }} <i class="fa-solid fa-sort"></i></th>
@@ -134,9 +135,6 @@
         </table>
     `;
             }
-
-
-
 
             // Add click listeners for sorting
             document.querySelectorAll(".sortable").forEach(header => {
@@ -204,8 +202,6 @@
             });
         }
 
-
-
         // Function to filter strains based on search
         function filterStrains(data, query) {
             if (!query) return data;
@@ -239,7 +235,6 @@
         fetchStrains(currentView);
     });
 </script>
-
 
 <!--Embed the footer.html template at this location-->
 {{ template "common/footer.html" .}}


### PR DESCRIPTION
I don't personal like using light UIs but someone wanted it so...

- Implemented a JavaScript-based theme toggle in `theme.js`.
- Updated `header2.html` to include a dark/light mode toggle button.
- Refactored `main.js` to dynamically apply theme-based text and background classes.
- Updated `strains.html` to support dynamic table theme application using localStorage.
- Added custom CSS variables and styles in `isley.css` for dark and light modes.
- Enhanced dropdowns, buttons, tables, and other UI components with theme-aware styling.

UI toggle:
![image](https://github.com/user-attachments/assets/ba14f5a8-b089-424a-944e-1aa15d0e94e2)

Light UI example:
![image](https://github.com/user-attachments/assets/008a86a7-952a-4da4-9967-0f26d206412a)


Resolves #56 