### PR TITLE
Add multi-state sort icons and improve table sorting behavior

### DIFF
--- a/web/static/css/isley.css
+++ b/web/static/css/isley.css
@@ -231,12 +231,27 @@ th, td {
 /* MISC */
 .sortable {
     cursor: pointer;
+    white-space: nowrap;
 }
-.sortable.asc::after {
-    content: " ▲";
+.sortable .fa-sort,
+.sortable .fa-sort-up,
+.sortable .fa-sort-down {
+    margin-left: 0.35rem;
+    vertical-align: middle;
 }
-.sortable.desc::after {
-    content: " ▼";
+.sortable .fa-sort-up,
+.sortable .fa-sort-down {
+    display: none;
+}
+.sortable.asc .fa-sort,
+.sortable.desc .fa-sort {
+    display: none;
+}
+.sortable.asc .fa-sort-up {
+    display: inline-block;
+}
+.sortable.desc .fa-sort-down {
+    display: inline-block;
 }
 .thumbnail-img {
     cursor: pointer;

--- a/web/templates/views/plants.html
+++ b/web/templates/views/plants.html
@@ -39,13 +39,13 @@
                 <table class="table table-striped table-bordered table-hover">
                     <thead class="table-dark" id="plantsTableHeader">
                     <tr>
-                        <th scope="col" data-sort="name" data-type="text" class="sortable">{{ .lcl.title_plant }} <i class="fa-solid fa-sort"></i></th>
-                        <th scope="col" data-sort="strain_name" data-type="text" class="sortable">{{ .lcl.title_strain }} <i class="fa-solid fa-sort"></i></th>
-                        <th scope="col" data-sort="breeder_name" data-type="text" class="sortable">{{ .lcl.breeder }} <i class="fa-solid fa-sort"></i></th>
-                        <th scope="col" data-sort="status" data-type="text" class="sortable">{{ .lcl.title_status }} <i class="fa-solid fa-sort"></i></th>
-                        <th scope="col" data-sort="start_date" data-type="date" class="sortable">{{ .lcl.start_date }} <i class="fa-solid fa-sort"></i></th>
-                        <th scope="col" id="dynamicHeader1" class="sortable">{{ .lcl.current_week }} <i class="fa-solid fa-sort"></i></th>
-                        <th scope="col" id="dynamicHeader2" class="sortable">{{ .lcl.current_day }} <i class="fa-solid fa-sort"></i></th>
+                        <th scope="col" data-sort="name" data-type="text" class="sortable">{{ .lcl.title_plant }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                        <th scope="col" data-sort="strain_name" data-type="text" class="sortable">{{ .lcl.title_strain }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                        <th scope="col" data-sort="breeder_name" data-type="text" class="sortable">{{ .lcl.breeder }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                        <th scope="col" data-sort="status" data-type="text" class="sortable">{{ .lcl.title_status }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                        <th scope="col" data-sort="start_date" data-type="date" class="sortable">{{ .lcl.start_date }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                        <th scope="col" id="dynamicHeader1" class="sortable">{{ .lcl.current_week }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                        <th scope="col" id="dynamicHeader2" class="sortable">{{ .lcl.current_day }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
                     </tr>
                     </thead>
                     <tbody id="plantsTableBody">
@@ -93,13 +93,14 @@
                 .catch(err => console.error("Error fetching plants:", err));
         };
 
+        const sortIconMarkup = ' <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i>';
         const updateHeaders = (view) => {
             if (view === "harvested") {
                 headerDynamic1.textContent = "{{ .lcl.harvest_weight_g }}";
                 headerDynamic2.textContent = "{{ .lcl.harvest_date }}";
-                //append  <i class="fa-solid fa-sort"></i> to the headers
-                headerDynamic1.innerHTML += '<i class="fa-solid fa-sort"></i>';
-                headerDynamic2.innerHTML += '<i class="fa-solid fa-sort"></i>';
+                // Append sort icons to the headers.
+                headerDynamic1.innerHTML += sortIconMarkup;
+                headerDynamic2.innerHTML += sortIconMarkup;
                 //Set data-sort and data-type for the columns
                 headerDynamic1.setAttribute("data-sort", "harvest_weight");
                 headerDynamic1.setAttribute("data-type", "number");
@@ -108,17 +109,17 @@
             } else if (view === "dead") {
                 headerDynamic1.textContent = "{{ .lcl.dead_date }}";
                 headerDynamic2.textContent = ""; // Hide second header
-                //append  <i class="fa-solid fa-sort"></i> to the headers
-                headerDynamic1.innerHTML += '<i class="fa-solid fa-sort"></i>';
+                // Append sort icons to the headers.
+                headerDynamic1.innerHTML += sortIconMarkup;
                 //Set data-sort and data-type for the columns
                 headerDynamic1.setAttribute("data-sort", "harvest_date");
                 headerDynamic1.setAttribute("data-type", "date");
             } else {
                 headerDynamic1.textContent = "{{ .lcl.current_week }}";
                 headerDynamic2.textContent = "{{ .lcl.current_day }}";
-                //append  <i class="fa-solid fa-sort"></i> to the headers
-                headerDynamic1.innerHTML += '<i class="fa-solid fa-sort"></i>';
-                headerDynamic2.innerHTML += '<i class="fa-solid fa-sort"></i>';
+                // Append sort icons to the headers.
+                headerDynamic1.innerHTML += sortIconMarkup;
+                headerDynamic2.innerHTML += sortIconMarkup;
                 //Set data-sort and data-type for the columns
                 headerDynamic1.setAttribute("data-sort", "current_week");
                 headerDynamic1.setAttribute("data-type", "number");
@@ -206,6 +207,10 @@
                     sortColumn = column;
                     sortDirection = "asc";
                 }
+                document.querySelectorAll(".sortable").forEach(item => {
+                    item.classList.remove("asc", "desc");
+                });
+                header.classList.add(sortDirection);
                 updateTable();
             });
         });

--- a/web/templates/views/strains.html
+++ b/web/templates/views/strains.html
@@ -93,10 +93,10 @@
         <table class="table table-striped table-bordered table-hover">
             <thead class="${themeTableClass}">
                 <tr>
-                    <th scope="col" data-key="name" data-type="text" class="sortable ${currentSort.key === "name" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.title_strain }} <i class="fa-solid fa-sort"></i></th>
-                    <th scope="col" data-key="breeder" data-type="text" class="sortable ${currentSort.key === "breeder" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.breeder }} <i class="fa-solid fa-sort"></i></th>
-                    <th scope="col" data-key="short_desc" data-type="text" class="sortable ${currentSort.key === "short_desc" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.description_txt }} <i class="fa-solid fa-sort"></i></th>
-                    <th scope="col" data-key="seed_count" data-type="numeric" class="sortable ${currentSort.key === "seed_count" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.seed_count }} <i class="fa-solid fa-sort"></i></th>
+                    <th scope="col" data-key="name" data-type="text" class="sortable ${currentSort.key === "name" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.title_strain }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                    <th scope="col" data-key="breeder" data-type="text" class="sortable ${currentSort.key === "breeder" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.breeder }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                    <th scope="col" data-key="short_desc" data-type="text" class="sortable ${currentSort.key === "short_desc" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.description_txt }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                    <th scope="col" data-key="seed_count" data-type="numeric" class="sortable ${currentSort.key === "seed_count" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.seed_count }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
                     <th scope="col" colspan="2"> </th>
                 </tr>
             </thead>
@@ -109,10 +109,10 @@
         <table class="table table-striped table-bordered table-hover">
             <thead class="${themeTableClass}">
                 <tr>
-                    <th scope="col" data-key="name" data-type="text" class="sortable ${currentSort.key === "name" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.title_strain }} <i class="fa-solid fa-sort"></i></th>
-                    <th scope="col" data-key="breeder" data-type="text" class="sortable ${currentSort.key === "breeder" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.breeder }} <i class="fa-solid fa-sort"></i></th>
-                    <th scope="col" data-key="short_desc" data-type="text" class="sortable ${currentSort.key === "short_desc" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.description_txt }} <i class="fa-solid fa-sort"></i></th>
-                    <th scope="col" data-key="seed_count" data-type="numeric" class="sortable ${currentSort.key === "seed_count" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.seed_count }} <i class="fa-solid fa-sort"></i></th>
+                    <th scope="col" data-key="name" data-type="text" class="sortable ${currentSort.key === "name" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.title_strain }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                    <th scope="col" data-key="breeder" data-type="text" class="sortable ${currentSort.key === "breeder" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.breeder }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                    <th scope="col" data-key="short_desc" data-type="text" class="sortable ${currentSort.key === "short_desc" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.description_txt }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
+                    <th scope="col" data-key="seed_count" data-type="numeric" class="sortable ${currentSort.key === "seed_count" ? (currentSort.isAscending ? "asc" : "desc") : ""}">{{ .lcl.seed_count }} <i class="fa-solid fa-sort"></i><i class="fa-solid fa-sort-up"></i><i class="fa-solid fa-sort-down"></i></th>
                     <th scope="col" colspan="2"> </th>
                 </tr>
             </thead>


### PR DESCRIPTION
- Enhanced table headers to display multi-state sort icons (`fa-sort`, `fa-sort-up`, `fa-sort-down`) for improved visual clarity.
- Extracted sort icon markup into a reusable constant in JavaScript for cleaner code.
- Updated sorting logic to toggle sort direction classes (`asc`, `desc`) dynamically, ensuring consistent behavior across tables.
- Modified CSS rules for `.sortable` to hide non-relevant sort icons and improve alignment.
- Applied changes to both `plants.html` and `strains.html` templates for consistent UI improvements.
- Added `white-space: nowrap` styling for `.sortable` headers to prevent text wrapping.