### PR TITLE
Add "UpdatePlantStatus" handler and implement quick status edit functionality

### DIFF
--- a/handlers/plant.go
+++ b/handlers/plant.go
@@ -1012,20 +1012,12 @@ func UpdatePlant(c *gin.Context) {
 	}
 
 	//Update the Plant Status Log
-	//Check the current status and do not update if it's unchanged
-	var currentStatus int
-	err = db.QueryRow("SELECT status_id FROM plant_status_log WHERE plant_id = $1 ORDER BY date DESC LIMIT 1", input.PlantID).Scan(&currentStatus)
+	updated, err := updatePlantStatusLog(db, input.PlantID, input.StatusID, input.Date)
 	if err != nil {
-		fieldLogger.WithError(err).Error("Failed to get current status")
+		fieldLogger.WithError(err).Error("Failed to update plant status")
 		return
 	}
-	if currentStatus != input.StatusID {
-		_, err = db.Exec("INSERT INTO plant_status_log (plant_id, status_id, date) VALUES ($1, $2, $3)", input.PlantID, input.StatusID, input.Date)
-		if err != nil {
-			fieldLogger.WithError(err).Error("Failed to update plant status")
-			return
-		}
-	} else {
+	if !updated {
 		fieldLogger.Info("Plant status unchanged")
 	}
 	c.JSON(http.StatusCreated, input)

--- a/handlers/plant_status_update.go
+++ b/handlers/plant_status_update.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"isley/logger"
+	model "isley/model"
+)
+
+const statusDateTimeLayout = "2006-01-02T15:04"
+
+func updatePlantStatusLog(db *sql.DB, plantID int, statusID int, date string) (bool, error) {
+	if date == "" {
+		date = time.Now().Format(statusDateTimeLayout)
+	}
+
+	var currentStatus int
+	err := db.QueryRow("SELECT status_id FROM plant_status_log WHERE plant_id = $1 ORDER BY date DESC LIMIT 1", plantID).Scan(&currentStatus)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, err
+	}
+	if err == nil && currentStatus == statusID {
+		return false, nil
+	}
+
+	_, err = db.Exec("INSERT INTO plant_status_log (plant_id, status_id, date) VALUES ($1, $2, $3)", plantID, statusID, date)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func UpdatePlantStatus(c *gin.Context) {
+	fieldLogger := logger.Log.WithFields(logrus.Fields{
+		"handler": "UpdatePlantStatus",
+	})
+
+	var input struct {
+		PlantID  int    `json:"plant_id"`
+		StatusID int    `json:"status_id"`
+		Date     string `json:"date"`
+	}
+
+	if err := c.ShouldBindJSON(&input); err != nil {
+		fieldLogger.WithError(err).Error("Invalid input")
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	fieldLogger = fieldLogger.WithFields(logrus.Fields{
+		"plant_id":  input.PlantID,
+		"status_id": input.StatusID,
+	})
+
+	if input.PlantID == 0 || input.StatusID == 0 {
+		fieldLogger.Error("Plant ID and status ID are required")
+		c.JSON(http.StatusBadRequest, gin.H{"error": "plant_id and status_id are required"})
+		return
+	}
+
+	db, err := model.GetDB()
+	if err != nil {
+		fieldLogger.WithError(err).Error("Failed to connect to database")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Database error"})
+		return
+	}
+
+	updated, err := updatePlantStatusLog(db, input.PlantID, input.StatusID, input.Date)
+	if err != nil {
+		fieldLogger.WithError(err).Error("Failed to update plant status")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update plant status"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"updated": updated})
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -38,6 +38,7 @@ func AddBasicRoutes(r *gin.RouterGroup, version string) {
 			"zones":           config.Zones,
 			"strains":         config.Strains,
 			"statuses":        config.Statuses,
+			"measurements":    config.Metrics,
 			"breeders":        config.Breeders,
 			"plants":          handlers.GetLivingPlants(),
 			"activities":      config.Activities,
@@ -149,6 +150,7 @@ func AddProtectedApiRoutes(r *gin.RouterGroup) {
 	// API endpoints
 	r.POST("/plants", handlers.AddPlant)
 	r.POST("/plant", func(c *gin.Context) { handlers.UpdatePlant(c) })
+	r.POST("/plant/status", handlers.UpdatePlantStatus)
 	r.DELETE("/plant/delete/:id", handlers.DeletePlant)
 	r.POST("/plant/link-sensors", handlers.LinkSensorsToPlant)
 	r.POST("/plantStatus/edit", handlers.EditStatus)

--- a/web/templates/views/plants.html
+++ b/web/templates/views/plants.html
@@ -46,6 +46,9 @@
                         <th scope="col" data-sort="start_date" data-type="date" class="sortable">{{ .lcl.start_date }} <i class="fa-solid fa-sort"></i></th>
                         <th scope="col" id="dynamicHeader1" class="sortable">{{ .lcl.current_week }} <i class="fa-solid fa-sort"></i></th>
                         <th scope="col" id="dynamicHeader2" class="sortable">{{ .lcl.current_day }} <i class="fa-solid fa-sort"></i></th>
+                        {{ if .loggedIn }}
+                        <th scope="col"></th>
+                        {{ end }}
                     </tr>
                     </thead>
                     <tbody id="plantsTableBody">
@@ -60,6 +63,115 @@
 <!-- Add Plant Modal -->
 {{ template "modals/add-plant-modal.html" .}}
 
+{{ if .loggedIn }}
+<div class="modal fade" id="quickStatusModal" tabindex="-1" aria-labelledby="quickStatusModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="quickStatusModalLabel">{{ .lcl.change_status }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ .lcl.title_close }}"></button>
+            </div>
+            <div class="modal-body">
+                <form id="quickStatusForm">
+                    <input type="hidden" id="quickStatusPlantId">
+                    <div class="mb-3">
+                        <label for="quickStatusPlantName" class="form-label">{{ .lcl.plant_name }}</label>
+                        <input type="text" class="form-control" id="quickStatusPlantName" readonly>
+                    </div>
+                    <div class="mb-3">
+                        <label for="quickStatusSelect" class="form-label">{{ .lcl.title_status }}</label>
+                        <select class="form-select" id="quickStatusSelect" required>
+                            {{ range .statuses }}
+                            <option value="{{ .ID }}">{{ .Status }}</option>
+                            {{ end }}
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="quickStatusDate" class="form-label">{{ .lcl.effective_date }}</label>
+                        <input type="datetime-local" class="form-control" id="quickStatusDate" required value="{{ now | formatDateTimeLocal }}">
+                    </div>
+                    <button type="submit" class="btn btn-primary">{{ .lcl.change_status }}</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="quickMeasurementModal" tabindex="-1" aria-labelledby="quickMeasurementModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="quickMeasurementModalLabel">{{ .lcl.add_measurement }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ .lcl.title_close }}"></button>
+            </div>
+            <div class="modal-body">
+                <form id="quickMeasurementForm">
+                    <input type="hidden" id="quickMeasurementPlantId">
+                    <div class="mb-3">
+                        <label for="quickMeasurementPlantName" class="form-label">{{ .lcl.plant_name }}</label>
+                        <input type="text" class="form-control" id="quickMeasurementPlantName" readonly>
+                    </div>
+                    <div class="mb-3">
+                        <label for="quickMeasurementMetric" class="form-label">{{ .lcl.measurement_name }}</label>
+                        <select class="form-select" id="quickMeasurementMetric" required>
+                            {{ range .measurements }}
+                            <option value="{{ .ID }}">{{ .Name }}</option>
+                            {{ end }}
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="quickMeasurementValue" class="form-label">{{ .lcl.measurement_value }}</label>
+                        <input type="number" class="form-control" id="quickMeasurementValue" step="any" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="quickMeasurementDate" class="form-label">{{ .lcl.title_date }}</label>
+                        <input type="datetime-local" class="form-control" id="quickMeasurementDate" required value="{{ now | formatDateTimeLocal }}">
+                    </div>
+                    <button type="submit" class="btn btn-primary">{{ .lcl.add_measurement }}</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="quickActivityModal" tabindex="-1" aria-labelledby="quickActivityModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="quickActivityModalLabel">{{ .lcl.add_activity }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ .lcl.title_close }}"></button>
+            </div>
+            <div class="modal-body">
+                <form id="quickActivityForm">
+                    <input type="hidden" id="quickActivityPlantId">
+                    <div class="mb-3">
+                        <label for="quickActivityPlantName" class="form-label">{{ .lcl.plant_name }}</label>
+                        <input type="text" class="form-control" id="quickActivityPlantName" readonly>
+                    </div>
+                    <div class="mb-3">
+                        <label for="quickActivityName" class="form-label">{{ .lcl.activity_name }}</label>
+                        <select class="form-select" id="quickActivityName" required>
+                            {{ range .activities }}
+                            <option value="{{ .ID }}">{{ .Name }}</option>
+                            {{ end }}
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="quickActivityNote" class="form-label">{{ .lcl.activity_note }}</label>
+                        <textarea class="form-control" id="quickActivityNote" rows="3"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="quickActivityDate" class="form-label">{{ .lcl.title_date }}</label>
+                        <input type="datetime-local" class="form-control" id="quickActivityDate" required value="{{ now | formatDateTimeLocal }}">
+                    </div>
+                    <button type="submit" class="btn btn-primary">{{ .lcl.add_activity }}</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{{ end }}
+
 <script>
     document.addEventListener("DOMContentLoaded", () => {
         const plantsTableBody = document.getElementById("plantsTableBody");
@@ -67,6 +179,45 @@
         const viewButtons = document.querySelectorAll(".view-button");
         const headerDynamic1 = document.getElementById("dynamicHeader1");
         const headerDynamic2 = document.getElementById("dynamicHeader2");
+        const statusOptionsRaw = {{ json .statuses }};
+        const parsedStatusOptions = typeof statusOptionsRaw === "string"
+            ? JSON.parse(statusOptionsRaw || "[]")
+            : statusOptionsRaw;
+        const statusOptions = Array.isArray(parsedStatusOptions) ? parsedStatusOptions : [];
+        const canEditStatus = {{ if .loggedIn }}true{{ else }}false{{ end }};
+        const statusIdByName = new Map(statusOptions.map(status => [status.status, status.id]));
+        const statusUpdateError = "{{ .lcl.failed_to_change_status }}";
+        const measurementAddError = "{{ .lcl.failed_to_add_measurement }}";
+        const activityAddError = "{{ .lcl.failed_to_add_activity }}";
+        const quickStatusModalElement = document.getElementById("quickStatusModal");
+        const quickStatusForm = document.getElementById("quickStatusForm");
+        const quickStatusPlantIdInput = document.getElementById("quickStatusPlantId");
+        const quickStatusPlantNameInput = document.getElementById("quickStatusPlantName");
+        const quickStatusSelect = document.getElementById("quickStatusSelect");
+        const quickStatusDate = document.getElementById("quickStatusDate");
+        const quickStatusModal = quickStatusModalElement && window.bootstrap
+            ? new bootstrap.Modal(quickStatusModalElement)
+            : null;
+        const quickMeasurementModalElement = document.getElementById("quickMeasurementModal");
+        const quickMeasurementForm = document.getElementById("quickMeasurementForm");
+        const quickMeasurementPlantIdInput = document.getElementById("quickMeasurementPlantId");
+        const quickMeasurementPlantNameInput = document.getElementById("quickMeasurementPlantName");
+        const quickMeasurementMetric = document.getElementById("quickMeasurementMetric");
+        const quickMeasurementValue = document.getElementById("quickMeasurementValue");
+        const quickMeasurementDate = document.getElementById("quickMeasurementDate");
+        const quickMeasurementModal = quickMeasurementModalElement && window.bootstrap
+            ? new bootstrap.Modal(quickMeasurementModalElement)
+            : null;
+        const quickActivityModalElement = document.getElementById("quickActivityModal");
+        const quickActivityForm = document.getElementById("quickActivityForm");
+        const quickActivityPlantIdInput = document.getElementById("quickActivityPlantId");
+        const quickActivityPlantNameInput = document.getElementById("quickActivityPlantName");
+        const quickActivityName = document.getElementById("quickActivityName");
+        const quickActivityNote = document.getElementById("quickActivityNote");
+        const quickActivityDate = document.getElementById("quickActivityDate");
+        const quickActivityModal = quickActivityModalElement && window.bootstrap
+            ? new bootstrap.Modal(quickActivityModalElement)
+            : null;
         let currentView = "living";
         let plantsData = [];
         let sortColumn = null;
@@ -127,6 +278,234 @@
             }
         };
 
+        const formatDateTimeLocal = (date) => {
+            const offsetDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+            return offsetDate.toISOString().slice(0, 16);
+        };
+
+        const initTooltips = () => {
+            if (!window.bootstrap || !bootstrap.Tooltip) {
+                return;
+            }
+            document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((element) => {
+                bootstrap.Tooltip.getOrCreateInstance(element);
+            });
+        };
+
+        const renderQuickActionsCell = (plant) => {
+            if (!canEditStatus) {
+                return "";
+            }
+            const statusId = statusIdByName.get(plant.status) || "";
+            const encodedName = encodeURIComponent(plant.name || "");
+            return `
+                    <td>
+                        <div class="d-inline-flex gap-1">
+                            <button type="button" class="btn btn-sm btn-outline-secondary plant-status-edit" data-id="${plant.id}" data-status-id="${statusId}" data-name="${encodedName}" data-bs-toggle="tooltip" data-bs-title="{{ .lcl.change_status }}" aria-label="{{ .lcl.change_status }}">
+                                <i class="fa-solid fa-pen-to-square"></i>
+                            </button>
+                            <button type="button" class="btn btn-sm btn-outline-primary plant-measurement-add" data-id="${plant.id}" data-name="${encodedName}" data-bs-toggle="tooltip" data-bs-title="{{ .lcl.add_measurement }}" aria-label="{{ .lcl.add_measurement }}">
+                                <i class="fa-solid fa-ruler-combined"></i>
+                            </button>
+                            <button type="button" class="btn btn-sm btn-outline-success plant-activity-add" data-id="${plant.id}" data-name="${encodedName}" data-bs-toggle="tooltip" data-bs-title="{{ .lcl.add_activity }}" aria-label="{{ .lcl.add_activity }}">
+                                <i class="fa-solid fa-clipboard-list"></i>
+                            </button>
+                        </div>
+                    </td>
+                `;
+        };
+
+        const attachQuickActionHandlers = () => {
+            if (!canEditStatus) {
+                return;
+            }
+
+            document.querySelectorAll(".plant-status-edit").forEach(button => {
+                button.addEventListener("click", (event) => {
+                    event.stopPropagation();
+                    const plantId = Number(button.dataset.id);
+                    const statusId = button.dataset.statusId ? Number(button.dataset.statusId) : null;
+                    const plantName = decodeURIComponent(button.dataset.name || "");
+                    if (!quickStatusModal) {
+                        return;
+                    }
+
+                    quickStatusPlantIdInput.value = plantId ? String(plantId) : "";
+                    quickStatusPlantNameInput.value = plantName;
+                    if (statusId) {
+                        quickStatusSelect.value = String(statusId);
+                    }
+                    quickStatusDate.value = formatDateTimeLocal(new Date());
+                    quickStatusModal.show();
+                });
+            });
+
+            document.querySelectorAll(".plant-measurement-add").forEach(button => {
+                button.addEventListener("click", (event) => {
+                    event.stopPropagation();
+                    const plantId = Number(button.dataset.id);
+                    const plantName = decodeURIComponent(button.dataset.name || "");
+                    if (!quickMeasurementModal || !plantId) {
+                        return;
+                    }
+                    quickMeasurementPlantIdInput.value = String(plantId);
+                    quickMeasurementPlantNameInput.value = plantName;
+                    quickMeasurementValue.value = "";
+                    quickMeasurementDate.value = formatDateTimeLocal(new Date());
+                    quickMeasurementModal.show();
+                });
+            });
+
+            document.querySelectorAll(".plant-activity-add").forEach(button => {
+                button.addEventListener("click", (event) => {
+                    event.stopPropagation();
+                    const plantId = Number(button.dataset.id);
+                    const plantName = decodeURIComponent(button.dataset.name || "");
+                    if (!quickActivityModal || !plantId) {
+                        return;
+                    }
+                    quickActivityPlantIdInput.value = String(plantId);
+                    quickActivityPlantNameInput.value = plantName;
+                    quickActivityNote.value = "";
+                    quickActivityDate.value = formatDateTimeLocal(new Date());
+                    quickActivityModal.show();
+                });
+            });
+        };
+
+        if (canEditStatus && quickStatusForm) {
+            quickStatusForm.addEventListener("submit", (event) => {
+                event.preventDefault();
+                const plantId = Number(quickStatusPlantIdInput.value);
+                const statusId = Number(quickStatusSelect.value);
+                const date = quickStatusDate.value;
+
+                if (!plantId || !statusId) {
+                    return;
+                }
+
+                const payload = {
+                    plant_id: plantId,
+                    status_id: statusId,
+                    date: date || formatDateTimeLocal(new Date()),
+                };
+
+                fetch("/plant/status", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify(payload),
+                })
+                    .then(response => {
+                        if (!response.ok) {
+                            throw new Error(statusUpdateError);
+                        }
+                        return response.json();
+                    })
+                    .then(() => {
+                        if (quickStatusModal) {
+                            quickStatusModal.hide();
+                        }
+                        fetchPlants(currentView);
+                    })
+                    .catch(err => {
+                        console.error("Error updating status:", err);
+                        alert(statusUpdateError);
+                    });
+            });
+        }
+
+        if (canEditStatus && quickMeasurementForm) {
+            quickMeasurementForm.addEventListener("submit", (event) => {
+                event.preventDefault();
+                const plantId = Number(quickMeasurementPlantIdInput.value);
+                const metricId = Number(quickMeasurementMetric.value);
+                const value = Number(quickMeasurementValue.value);
+                const date = quickMeasurementDate.value;
+
+                if (!plantId || !metricId || Number.isNaN(value)) {
+                    return;
+                }
+
+                const payload = {
+                    plant_id: plantId,
+                    metric_id: metricId,
+                    value: value,
+                    date: date || formatDateTimeLocal(new Date()),
+                };
+
+                fetch("/plantMeasurement", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify(payload),
+                })
+                    .then(response => {
+                        if (!response.ok) {
+                            throw new Error(measurementAddError);
+                        }
+                        return response.json();
+                    })
+                    .then(() => {
+                        if (quickMeasurementModal) {
+                            quickMeasurementModal.hide();
+                        }
+                        fetchPlants(currentView);
+                    })
+                    .catch(err => {
+                        console.error("Error adding measurement:", err);
+                        alert(measurementAddError);
+                    });
+            });
+        }
+
+        if (canEditStatus && quickActivityForm) {
+            quickActivityForm.addEventListener("submit", (event) => {
+                event.preventDefault();
+                const plantId = Number(quickActivityPlantIdInput.value);
+                const activityId = Number(quickActivityName.value);
+                const note = quickActivityNote.value;
+                const date = quickActivityDate.value;
+
+                if (!plantId || !activityId) {
+                    return;
+                }
+
+                const payload = {
+                    plant_id: plantId,
+                    activity_id: activityId,
+                    note: note,
+                    date: date || formatDateTimeLocal(new Date()),
+                };
+
+                fetch("/plantActivity", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify(payload),
+                })
+                    .then(response => {
+                        if (!response.ok) {
+                            throw new Error(activityAddError);
+                        }
+                        return response.json();
+                    })
+                    .then(() => {
+                        if (quickActivityModal) {
+                            quickActivityModal.hide();
+                        }
+                        fetchPlants(currentView);
+                    })
+                    .catch(err => {
+                        console.error("Error adding activity:", err);
+                        alert(activityAddError);
+                    });
+            });
+        }
+
         const updateTable = () => {
             const searchTerm = searchPlants.value.toLowerCase();
             let filteredPlants = plantsData.filter(plant =>
@@ -172,17 +551,25 @@
                     <td>${plant.start_dt ? new Date(plant.start_dt).toLocaleDateString() : "-"}</td>
                     <td>${column1}</td>
                     <td>${column2}</td>
+                    ${renderQuickActionsCell(plant)}
                 </tr>
             `;
             }).join("");
 
             // Add click events for rows
             document.querySelectorAll(".clickable-row").forEach(row => {
-                row.addEventListener("click", () => {
+                row.addEventListener("click", (event) => {
+                    if (event.target.closest(".plant-status-edit") ||
+                        event.target.closest(".plant-measurement-add") ||
+                        event.target.closest(".plant-activity-add")) {
+                        return;
+                    }
                     const plantId = row.getAttribute("data-id");
                     if (plantId) window.location.href = `/plant/${plantId}`;
                 });
             });
+            attachQuickActionHandlers();
+            initTooltips();
         };
 
         // Handle view button click


### PR DESCRIPTION
- Introduced `UpdatePlantStatus` handler in `plant_status_update.go` to manage plant status updates via API.
- Added reusable `updatePlantStatusLog` function to handle database updates for plant status logs.
- Refactored `handlers/plant.go` to use the new `updatePlantStatusLog` for improved code reuse.
- Updated `plants.html` to include quick action modals for status, measurement, and activity updates when logged in.
- Implemented JavaScript logic for quick status, measurement, and activity updates, including modals and API calls.
- Modified `routes.go` to add `/plant/status` endpoint.
- Enhanced dynamic table rendering with additional quick action buttons in the plants view.