### PR TITLE
Fixed quick actions cell not displaying on plants table

### DIFF
--- a/web/templates/views/plants.html
+++ b/web/templates/views/plants.html
@@ -552,6 +552,7 @@
                     <td>${plant.start_dt ? new Date(plant.start_dt).toLocaleDateString() : "-"}</td>
                     <td>${column1}</td>
                     <td>${column2}</td>
+                    ${renderQuickActionsCell(plant)}
                 </tr>
             `;
             }).join("");


### PR DESCRIPTION
- Updated `plants.html` to include a call to `renderQuickActionsCell(plant)` for displaying quick action buttons in the table.

Sorry @dwot, I made a slight mistake and missed this line, it wasn't displaying the quick action icons.