### PR TITLE
Fixed datetime validation in change status dialog

### DIFF
--- a/web/templates/views/plants.html
+++ b/web/templates/views/plants.html
@@ -89,7 +89,7 @@
                     </div>
                     <div class="mb-3">
                         <label for="quickStatusDate" class="form-label">{{ .lcl.effective_date }}</label>
-                        <input type="datetime-local" class="form-control" id="quickStatusDate" required value="{{ now | formatDateTimeLocal }}">
+                        <input type="datetime-local" class="form-control" id="quickStatusDate" step="1" required value="{{ now | formatDateTimeLocal }}">
                     </div>
                     <button type="submit" class="btn btn-primary">{{ .lcl.change_status }}</button>
                 </form>


### PR DESCRIPTION
- Updated `plants.html` to include `step="1"` in the `datetime-local` input field for the quick status date.
- Ensures compatibility with second-level precision for date-time validation.