### PR TITLE
Add session-based redirect for logged-in users on login route

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,6 +228,13 @@ func main() {
 
 	// Public routes
 	r.GET("/login", func(c *gin.Context) {
+		session := sessions.Default(c)
+		loggedIn := session.Get("logged_in")
+		if loggedIn != nil && loggedIn.(bool) {
+			c.Redirect(http.StatusFound, "/")
+			return
+		}
+
 		lang := utils.GetLanguage(c)
 		translations := utils.TranslationService.GetTranslations(lang)
 		c.HTML(http.StatusOK, "views/login.html", gin.H{


### PR DESCRIPTION
- Implemented session check in `/login` route to detect if the user is already logged in.
- Redirect logged-in users to the homepage (`/`) to prevent unnecessary access to the login page.