### PR TITLE
Extend the UI to allow switching to previous/next plant

### DIFF
--- a/handlers/plant.go
+++ b/handlers/plant.go
@@ -1120,4 +1120,36 @@ func DeadPlantsHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, plants)
 }
 
+// GetAdjacentPlantIDs returns the prev and next plant IDs within the same status group,
+// ordered by start_dt then name. Returns 0, 0 when there is no adjacent plant.
+func GetAdjacentPlantIDs(db *sql.DB, currentID int) (prevID, nextID int) {
+	fieldLogger := logger.Log.WithField("func", "GetAdjacentPlantIDs")
+
+	// Partition plants into status groups (active/not active),
+	// then use LAG/LEAD to get the neighbors of the requested plant.
+	const query = `
+		WITH ranked AS (
+			SELECT
+				p.id,
+				LAG(p.id)  OVER (PARTITION BY ps.active ORDER BY p.start_dt, p.name) AS prev_id,
+				LEAD(p.id) OVER (PARTITION BY ps.active ORDER BY p.start_dt, p.name) AS next_id
+			FROM plant p
+			JOIN plant_status_log psl ON p.id = psl.plant_id
+			JOIN plant_status ps      ON psl.status_id = ps.id
+			WHERE psl.date = (SELECT MAX(date) FROM plant_status_log WHERE plant_id = p.id)
+		)
+		SELECT COALESCE(prev_id, 0), COALESCE(next_id, 0)
+		FROM   ranked
+		WHERE  id = $1
+	`
+
+	if err := db.QueryRow(query, currentID).Scan(&prevID, &nextID); err != nil {
+		if err != sql.ErrNoRows {
+			fieldLogger.WithError(err).Error("Failed to query adjacent plant IDs")
+		}
+		return 0, 0
+	}
+	return prevID, nextID
+}
+
 // Strain and breeder handlers have been moved to strain.go

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -1,14 +1,15 @@
 package routes
 
 import (
-	"github.com/gin-contrib/sessions"
-	"github.com/gin-gonic/gin"
 	"isley/config"
 	"isley/handlers"
 	"isley/model"
 	"isley/utils"
 	"net/http"
 	"strconv"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
 )
 
 func AddBasicRoutes(r *gin.RouterGroup, version string) {
@@ -182,18 +183,22 @@ func AddBasicRoutes(r *gin.RouterGroup, version string) {
 		lang := utils.GetLanguage(c)
 		translations := utils.TranslationService.GetTranslations(lang)
 		currentPath, _ := c.Get("currentPath")
+		db := handlers.DBFromContext(c)
+		idStr := c.Param("id")
+		plant := handlers.GetPlant(db, idStr)
+		prevPlantID, nextPlantID := handlers.GetAdjacentPlantIDs(db, int(plant.ID))
 		c.HTML(http.StatusOK, "views/plant.html", gin.H{
 			"title":           "Plant Details",
 			"currentPath":     currentPath,
 			"version":         version,
-			"plant":           handlers.GetPlant(handlers.DBFromContext(c), c.Param("id")),
+			"plant":           plant,
 			"zones":           config.Zones,
 			"strains":         config.Strains,
 			"statuses":        config.Statuses,
 			"breeders":        config.Breeders,
 			"measurements":    config.Metrics,
-			"sensors":         handlers.GetSensors(handlers.DBFromContext(c)),
-			"plants":          handlers.GetLivingPlants(handlers.DBFromContext(c)),
+			"sensors":         handlers.GetSensors(db),
+			"plants":          handlers.GetLivingPlants(db),
 			"activities":      config.Activities,
 			"loggedIn":        sessions.Default(c).Get("logged_in"),
 			"lcl":             translations,
@@ -201,6 +206,8 @@ func AddBasicRoutes(r *gin.RouterGroup, version string) {
 			"currentLanguage": lang,
 			"csrfToken":       c.GetString("csrf_token"),
 			"cspNonce":        c.GetString("cspNonce"),
+			"prevPlantID":     prevPlantID,
+			"nextPlantID":     nextPlantID,
 		})
 	})
 

--- a/web/static/css/isley.css
+++ b/web/static/css/isley.css
@@ -2080,16 +2080,54 @@ header .nav-link.active::after {
     pointer-events: none;
 }
 .plant-hero--no-img .plant-hero-overlay { display: none; }
+/* Hero carousel-style nav arrows */
+.plant-hero-nav {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 3;
+    color: rgba(255,255,255,0.72);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    line-height: 1;
+    text-decoration: none;
+    text-shadow: 0 1px 3px rgba(0,0,0,0.45);
+    transition: color 0.18s, opacity 0.18s, transform 0.18s;
+    opacity: 0.8;
+    cursor: pointer;
+}
+.plant-hero-nav:hover {
+    color: #fff;
+    transform: translateY(-50%) scale(1.05);
+    opacity: 1;
+    text-decoration: none;
+}
+.plant-hero-nav--prev { left: 0.85rem; }
+.plant-hero-nav--next { right: 0.85rem; }
+.plant-hero--no-img .plant-hero-nav {
+    color: rgba(var(--bs-body-color-rgb, 33,37,41), 0.6);
+    text-shadow: none;
+}
+.plant-hero--no-img .plant-hero-nav:hover {
+    color: var(--color-accent);
+}
 .plant-hero-content {
     position: relative;
     z-index: 1;
     width: 100%;
-    padding: 1.25rem 1.5rem;
+    padding: 1.25rem 2.6rem;
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
     gap: 1rem;
     flex-wrap: wrap;
+}
+@media (max-width: 575.98px) {
+    .plant-hero-content {
+        padding: 1rem 2rem;
+    }
 }
 .plant-hero-title {
     font-size: 2rem;

--- a/web/templates/views/plant.html
+++ b/web/templates/views/plant.html
@@ -15,6 +15,16 @@
     <div class="plant-hero mb-4{{ if eq .plant.LatestImage.ImagePath "" }} plant-hero--no-img{{ end }}"
          {{ if ne .plant.LatestImage.ImagePath "" }}style="background-image:url('{{ .plant.LatestImage.ImagePath }}')"{{ end }}>
         <div class="plant-hero-overlay"></div>
+        {{ if .prevPlantID }}
+        <a href="/plant/{{ .prevPlantID }}" class="plant-hero-nav plant-hero-nav--prev" title="Previous plant" id="prevPlantLink">
+            <i class="fa-solid fa-chevron-left"></i>
+        </a>
+        {{ end }}
+        {{ if .nextPlantID }}
+        <a href="/plant/{{ .nextPlantID }}" class="plant-hero-nav plant-hero-nav--next" title="Next plant" id="nextPlantLink">
+            <i class="fa-solid fa-chevron-right"></i>
+        </a>
+        {{ end }}
         {{ if and .plant.Sensors (ne .plant.Status "Dead") (ne .plant.Status "Success") (ne .plant.Status "Drying") (ne .plant.Status "Curing") }}
         <div class="plant-hero-sensors">
             {{ range .plant.Sensors }}
@@ -712,6 +722,20 @@ document.addEventListener("DOMContentLoaded", () => {
             mGroupEl.appendChild(row);
         });
     }
+
+    // ===== Plant navigation (arrow keys) =====
+    var prevId = {{ .prevPlantID }};
+    var nextId = {{ .nextPlantID }};
+    document.addEventListener('keydown', function(e) {
+        var tag = document.activeElement && document.activeElement.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+        if (document.activeElement && document.activeElement.isContentEditable) return;
+        if (e.key === 'ArrowLeft' && prevId) {
+            window.location.href = '/plant/' + prevId;
+        } else if (e.key === 'ArrowRight' && nextId) {
+            window.location.href = '/plant/' + nextId;
+        }
+    });
 });
 </script>
 

--- a/web/templates/views/plant.html
+++ b/web/templates/views/plant.html
@@ -727,8 +727,13 @@ document.addEventListener("DOMContentLoaded", () => {
     var prevId = {{ .prevPlantID }};
     var nextId = {{ .nextPlantID }};
     document.addEventListener('keydown', function(e) {
+        // Don't navigate if the image modal is open...
+        var imageModal = document.getElementById('imageModal');
+        if (imageModal && imageModal.classList.contains('show')) return;
+        // ...focus is on an input, textarea, select...
         var tag = document.activeElement && document.activeElement.tagName;
         if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+        // ...or on a contenteditable enabled
         if (document.activeElement && document.activeElement.isContentEditable) return;
         if (e.key === 'ArrowLeft' && prevId) {
             window.location.href = '/plant/' + prevId;


### PR DESCRIPTION
This allows switching to the previous/next plant in the same state via
small arrows in the plant banner as well as left/right keys on the
keyboard.