### PR TITLE
Allow activities to be flagged as watering and/or feeding

### DIFF
--- a/handlers/constants.go
+++ b/handlers/constants.go
@@ -52,17 +52,6 @@ func isHumiditySensor(sensorType int) bool {
 }
 
 // ---------------------------------------------------------------------------
-// Activity type IDs — built-in activity identifiers
-// ---------------------------------------------------------------------------
-
-const (
-	// ActivityWater is the built-in "Water" activity.
-	ActivityWater = 1
-	// ActivityFeed is the built-in "Feed" activity.
-	ActivityFeed = 2
-)
-
-// ---------------------------------------------------------------------------
 // HTTP client timeouts
 // ---------------------------------------------------------------------------
 

--- a/handlers/plant.go
+++ b/handlers/plant.go
@@ -131,7 +131,7 @@ func AddPlant(c *gin.Context) {
 func GetActivities(db *sql.DB) []types.Activity {
 	fieldLogger := logger.Log.WithField("func", "GetActivities")
 
-	rows, err := db.Query("SELECT id, name FROM activity")
+	rows, err := db.Query("SELECT id, name, is_watering, is_feeding FROM activity")
 	if err != nil {
 		fieldLogger.WithError(err).Error("Failed to query activities")
 		return nil
@@ -140,7 +140,7 @@ func GetActivities(db *sql.DB) []types.Activity {
 	var activities []types.Activity
 	for rows.Next() {
 		var activity types.Activity
-		err = rows.Scan(&activity.ID, &activity.Name)
+		err = rows.Scan(&activity.ID, &activity.Name, &activity.IsWatering, &activity.IsFeeding)
 		if err != nil {
 			fieldLogger.WithError(err).Error("Failed to scan activity")
 			return nil
@@ -561,7 +561,14 @@ func loadPlantMeasurements(db *sql.DB, plantID uint) []types.Measurement {
 func loadPlantActivities(db *sql.DB, plantID uint) []types.PlantActivity {
 	fieldLogger := logger.Log.WithField("func", "loadPlantActivities")
 
-	rows, err := db.Query(fmt.Sprintf("SELECT pa.id, a.id AS activity_id, a.name, pa.note, pa.date FROM plant_activity pa LEFT OUTER JOIN activity a ON a.id = pa.activity_id WHERE pa.plant_id = $1 ORDER BY date DESC LIMIT %d", PlantHistoryLimit), plantID)
+	rows, err := db.Query(fmt.Sprintf(`
+		SELECT pa.id, a.id AS activity_id, a.name, pa.note, pa.date,
+		       a.is_watering, a.is_feeding
+		FROM plant_activity pa
+		LEFT OUTER JOIN activity a ON a.id = pa.activity_id
+		WHERE pa.plant_id = $1
+		ORDER BY date DESC
+		LIMIT %d`, PlantHistoryLimit), plantID)
 	if err != nil {
 		fieldLogger.WithError(err).Error("Failed to query activities")
 		return nil
@@ -574,11 +581,12 @@ func loadPlantActivities(db *sql.DB, plantID uint) []types.PlantActivity {
 		var activityID int
 		var name, note string
 		var date time.Time
-		if err := rows.Scan(&id, &activityID, &name, &note, &date); err != nil {
+		var isWatering, isFeeding bool
+		if err := rows.Scan(&id, &activityID, &name, &note, &date, &isWatering, &isFeeding); err != nil {
 			fieldLogger.WithError(err).Error("Failed to scan activity")
 			continue
 		}
-		activities = append(activities, types.PlantActivity{ID: id, Name: name, Note: note, Date: utils.AsLocal(date), ActivityId: activityID})
+		activities = append(activities, types.PlantActivity{ID: id, Name: name, Note: note, Date: utils.AsLocal(date), ActivityId: activityID, IsWatering: isWatering, IsFeeding: isFeeding})
 	}
 	return activities
 }
@@ -661,10 +669,10 @@ func loadPlantImages(db *sql.DB, plantID uint) (types.PlantImage, []types.PlantI
 // deriveActivityDates scans activities to find the most recent water and feed dates.
 func deriveActivityDates(activities []types.PlantActivity) (lastWater, lastFeed time.Time) {
 	for _, a := range activities {
-		if a.ActivityId == ActivityWater && a.Date.After(lastWater) {
+		if a.IsWatering && a.Date.After(lastWater) {
 			lastWater = a.Date
 		}
-		if a.ActivityId == ActivityFeed && a.Date.After(lastFeed) {
+		if a.IsFeeding && a.Date.After(lastFeed) {
 			lastFeed = a.Date
 		}
 	}
@@ -871,13 +879,13 @@ SELECT
 		SELECT (CURRENT_DATE - MAX(pa.date)::date)
 		FROM plant_activity pa
 		JOIN activity a ON pa.activity_id = a.id
-		WHERE pa.plant_id = p.id AND a.name = 'Water'
+		WHERE pa.plant_id = p.id AND a.is_watering = TRUE
 	), 0) AS days_since_last_watering,
 	COALESCE((
 		SELECT (CURRENT_DATE - MAX(pa.date)::date)
 		FROM plant_activity pa
 		JOIN activity a ON pa.activity_id = a.id
-		WHERE pa.plant_id = p.id AND a.name = 'Feed'
+		WHERE pa.plant_id = p.id AND a.is_feeding = TRUE
 	), 0) AS days_since_last_feeding,
 	COALESCE((
 		SELECT (
@@ -928,15 +936,15 @@ SELECT
     CAST((julianday('now', 'localtime') - julianday(p.start_dt)) + 1 AS INT) AS current_day,
     COALESCE((
         SELECT CAST(julianday('now', 'localtime') - julianday(MAX(pa.date)) AS INT)
-        FROM plant_activity pa 
-        JOIN activity a ON pa.activity_id = a.id
-        WHERE pa.plant_id = p.id AND a.name = 'Water'
+        FROM plant_activity pa
+		JOIN activity a ON pa.activity_id = a.id
+		WHERE pa.plant_id = p.id AND a.is_watering = TRUE
     ), 0) AS days_since_last_watering,
     COALESCE((
         SELECT CAST(julianday('now', 'localtime') - julianday(MAX(pa.date)) AS INT)
-        FROM plant_activity pa 
-        JOIN activity a ON pa.activity_id = a.id
-        WHERE pa.plant_id = p.id AND a.name = 'Feed'
+        FROM plant_activity pa
+		JOIN activity a ON pa.activity_id = a.id
+		WHERE pa.plant_id = p.id AND a.is_feeding = TRUE
     ), 0) AS days_since_last_feeding,
     COALESCE((
         SELECT CAST(

--- a/handlers/plant_activity.go
+++ b/handlers/plant_activity.go
@@ -1,10 +1,11 @@
 package handlers
 
 import (
-	"github.com/gin-gonic/gin"
-	"github.com/sirupsen/logrus"
 	"isley/logger"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 func CreatePlantActivity(c *gin.Context) {

--- a/handlers/settings.go
+++ b/handlers/settings.go
@@ -414,7 +414,9 @@ func AddMetricHandler(c *gin.Context) {
 func AddActivityHandler(c *gin.Context) {
 	fieldLogger := logger.Log.WithField("func", "AddActivityHandler")
 	var activity struct {
-		Name string `json:"activity_name"`
+		Name       string `json:"activity_name"`
+		IsWatering bool   `json:"is_watering"`
+		IsFeeding  bool   `json:"is_feeding"`
 	}
 	if err := c.ShouldBindJSON(&activity); err != nil {
 		fieldLogger.WithError(err).Error("Failed to add activity")
@@ -438,13 +440,16 @@ func AddActivityHandler(c *gin.Context) {
 
 	// Insert new activity and return new id
 	var id int
-	err := db.QueryRow("INSERT INTO activity (name) VALUES ($1) RETURNING id", activity.Name).Scan(&id)
+	err := db.QueryRow(`
+		INSERT INTO activity (name, is_watering, is_feeding)
+		VALUES ($1, $2, $3)
+		RETURNING id`, activity.Name, activity.IsWatering, activity.IsFeeding).Scan(&id)
 	if err != nil {
 		fieldLogger.WithError(err).Error("Failed to add activity")
 		apiInternalError(c, "api_failed_to_add_activity")
 		return
 	}
-	config.Activities = append(config.Activities, types.Activity{ID: id, Name: activity.Name})
+	config.Activities = append(config.Activities, types.Activity{ID: id, Name: activity.Name, IsWatering: activity.IsWatering, IsFeeding: activity.IsFeeding})
 
 	c.JSON(http.StatusCreated, gin.H{"id": id})
 }
@@ -536,7 +541,9 @@ func UpdateActivityHandler(c *gin.Context) {
 	fieldLogger := logger.Log.WithField("func", "UpdateActivityHandler")
 	id := c.Param("id")
 	var activity struct {
-		Name string `json:"activity_name"`
+		Name       string `json:"activity_name"`
+		IsWatering bool   `json:"is_watering"`
+		IsFeeding  bool   `json:"is_feeding"`
 	}
 	if err := c.ShouldBindJSON(&activity); err != nil {
 		fieldLogger.WithError(err).Error("Failed to update activity")
@@ -562,7 +569,10 @@ func UpdateActivityHandler(c *gin.Context) {
 	}
 
 	// Perform the update
-	_, err = db.Exec("UPDATE activity SET name = $1 WHERE id = $2", activity.Name, id)
+	_, err = db.Exec(`
+		UPDATE activity
+		SET name = $1, is_watering = $2, is_feeding = $3
+		WHERE id = $4`, activity.Name, activity.IsWatering, activity.IsFeeding, id)
 	if err != nil {
 		fieldLogger.WithError(err).Error("Failed to update activity")
 		apiInternalError(c, "api_failed_to_update_activity")

--- a/model/migrations/postgres/017_activity_defaults.postgres.down.sql
+++ b/model/migrations/postgres/017_activity_defaults.postgres.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE activity DROP COLUMN is_watering;
+ALTER TABLE activity DROP COLUMN is_feeding;

--- a/model/migrations/postgres/017_activity_defaults.postgres.up.sql
+++ b/model/migrations/postgres/017_activity_defaults.postgres.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE activity ADD COLUMN is_watering BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE activity ADD COLUMN is_feeding BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE activity SET is_watering = TRUE WHERE name = 'Water';
+UPDATE activity SET is_feeding = TRUE WHERE name = 'Feed';

--- a/model/migrations/sqlite/017_activity_defaults.sqlite.down.sql
+++ b/model/migrations/sqlite/017_activity_defaults.sqlite.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE activity DROP COLUMN is_watering;
+ALTER TABLE activity DROP COLUMN is_feeding;

--- a/model/migrations/sqlite/017_activity_defaults.sqlite.up.sql
+++ b/model/migrations/sqlite/017_activity_defaults.sqlite.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE activity ADD COLUMN is_watering BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE activity ADD COLUMN is_feeding BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE activity SET is_watering = TRUE WHERE name = 'Water';
+UPDATE activity SET is_feeding = TRUE WHERE name = 'Feed';

--- a/model/types/base_models.go
+++ b/model/types/base_models.go
@@ -10,11 +10,15 @@ type PlantActivity struct {
 	Note       string    `json:"note"`
 	Date       time.Time `json:"date"`
 	ActivityId int       `json:"activity_id"`
+	IsWatering bool      `json:"is_watering"`
+	IsFeeding  bool      `json:"is_feeding"`
 }
 
 type Activity struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	IsWatering bool   `json:"is_watering"`
+	IsFeeding  bool   `json:"is_feeding"`
 }
 
 type Breeder struct {

--- a/web/templates/modals/activity-edit-modal.html
+++ b/web/templates/modals/activity-edit-modal.html
@@ -26,6 +26,7 @@
                         <label for="editActivityNote" class="form-label">{{ .lcl.title_note }}</label>
                         <textarea class="form-control" id="editActivityNote" rows="3"></textarea>
                     </div>
+
                     {{ if .loggedIn }}
                     <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk"></i> {{ .lcl.save_changes }}</button>
                     <button type="button" class="btn btn-danger" id="deleteActivity"><i class="fa-solid fa-trash"></i> {{ .lcl.delete_activity }}</button>

--- a/web/templates/views/settings.html
+++ b/web/templates/views/settings.html
@@ -725,6 +725,15 @@ color: #0d6efd; /* Primary color */
                         <input type="text" class="form-control" id="activityName" step="any" required>
                     </div>
 
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="checkbox" id="activityIsWatering">
+                        <label class="form-check-label" for="activityIsWatering">Watering</label>
+                    </div>
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" id="activityIsFeeding">
+                        <label class="form-check-label" for="activityIsFeeding">Feeding</label>
+                    </div>
+
                     <!-- Submit Button -->
                     <button type="submit" class="btn btn-primary">{{ .lcl.add_activity }}</button>
                 </form>
@@ -824,6 +833,14 @@ color: #0d6efd; /* Primary color */
                     <div class="mb-3">
                         <label for="editActivityName" class="form-label">{{ .lcl.activity_name }}</label>
                         <input type="text" class="form-control" id="editActivityName" step="any" required>
+                    </div>
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="checkbox" id="editActivityIsWatering">
+                        <label class="form-check-label" for="editActivityIsWatering">Watering</label>
+                    </div>
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" id="editActivityIsFeeding">
+                        <label class="form-check-label" for="editActivityIsFeeding">Feeding</label>
                     </div>
                     <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk"></i> {{ .lcl.save_changes }}</button>
                     <button type="button" class="btn btn-danger" id="deleteActivity"><i class="fa-solid fa-trash"></i> {{ .lcl.delete_activity }}</button>
@@ -1278,10 +1295,14 @@ color: #0d6efd; /* Primary color */
             // Gather form data
             const activityId = document.getElementById("activityId").value;
             const activityName = document.getElementById("activityName").value;
+            const isWatering = document.getElementById("activityIsWatering").checked;
+            const isFeeding = document.getElementById("activityIsFeeding").checked;
 
             // Construct the payload
             const payload = {
                 activity_name: activityName,
+                is_watering: isWatering,
+                is_feeding: isFeeding,
             };
 
             // Send POST request to /plantMeasurement
@@ -1322,6 +1343,8 @@ color: #0d6efd; /* Primary color */
 
                 document.getElementById("activityId").value = activityData.id;
                 document.getElementById("editActivityName").value = activityData.name;
+                document.getElementById("editActivityIsWatering").checked = !!activityData.is_watering;
+                document.getElementById("editActivityIsFeeding").checked = !!activityData.is_feeding;
 
                 editActivityModal.show();
             });
@@ -1332,6 +1355,8 @@ color: #0d6efd; /* Primary color */
             const activityId = document.getElementById("activityId").value;
             const payload = {
                 activity_name: document.getElementById("editActivityName").value,
+                is_watering: document.getElementById("editActivityIsWatering").checked,
+                is_feeding: document.getElementById("editActivityIsFeeding").checked,
             };
 
             fetch(`/activities/${activityId}`, {


### PR DESCRIPTION
Allow users to mark activities to be watering and/or feeding.
This allows for more dynamic activity configurations or grouping of activities (like Watering & Feeding) to make entering them less involved.