### PR TITLE
EcoWitt: add ch_aisle (WH31/WN31) and common_list outdoor sensor support

### DIFF
--- a/handlers/sensors.go
+++ b/handlers/sensors.go
@@ -552,6 +552,38 @@ func ScanEcoWittSensors(c *gin.Context) {
 		unit := "%"
 		checkInsertSensor(db, source, device, sensorType, name, input.ZoneID, unit)
 	}
+
+	for _, ch := range apiResponse.CHAisle {
+		sensorType := "Aisle." + ch.Channel + ".Temp"
+		unit := "°F"
+		if ch.Unit == "C" {
+			unit = "°C"
+		}
+		checkInsertSensor(db, source, device, sensorType,
+			"EC ("+device+") Ch"+ch.Channel+" Temp", input.ZoneID, unit)
+		sensorType = "Aisle." + ch.Channel + ".Humi"
+		checkInsertSensor(db, source, device, sensorType,
+			"EC ("+device+") Ch"+ch.Channel+" Humi", input.ZoneID, "%")
+	}
+
+	for _, item := range apiResponse.CommonList {
+		meta, ok := types.ECWCommonSensors[types.NormalizeECWID(item.ID)]
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(item.Val, "--") {
+			continue
+		}
+		unit := meta.Unit
+		if item.Unit == "F" {
+			unit = "°F"
+		} else if item.Unit == "C" {
+			unit = "°C"
+		}
+		checkInsertSensor(db, source, device, meta.TypeKey,
+			fmt.Sprintf(meta.Name, device), input.ZoneID, unit)
+	}
+
 	//Update ECOWitt sensors
 	//Set ECDevices
 	strECDevices, err := LoadEcDevices(db)

--- a/model/types/ecowitt_models.go
+++ b/model/types/ecowitt_models.go
@@ -1,6 +1,11 @@
 package types
 
-// Define the structures to match the JSON response
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 type ECWWH25 struct {
 	InTemp string `json:"intemp"`
 	Unit   string `json:"unit"`
@@ -16,7 +21,74 @@ type ECWCHSoil struct {
 	Humidity string `json:"humidity"`
 }
 
+type ECWCHAisle struct {
+	Channel  string `json:"channel"`
+	Name     string `json:"name"`
+	Battery  string `json:"battery"`
+	Temp     string `json:"temp"`
+	Unit     string `json:"unit"`
+	Humidity string `json:"humidity"`
+}
+
+type ECWCommonItem struct {
+	ID      string `json:"id"`
+	Val     string `json:"val"`
+	Unit    string `json:"unit"`
+	Battery string `json:"battery"`
+}
+
+// ECWCommonSensors maps normalised lowercase hex ID strings to sensor
+// metadata used during both scan (registration) and poll (data ingestion).
+// IDs 0x01/0x06 (indoor T&H — duplicates of wh25) and 0x18 (date/time
+// string) are intentionally absent.
+var ECWCommonSensors = map[string]struct {
+	TypeKey string
+	Name    string
+	Unit    string
+}{
+	"0x02": {"Common.0x02", "EC (%s) Outdoor Temp",     "°F"},
+	"0x03": {"Common.0x03", "EC (%s) Dew Point",        "°F"},
+	"0x04": {"Common.0x04", "EC (%s) Wind Chill",       "°F"},
+	"0x05": {"Common.0x05", "EC (%s) Heat Index",       "°F"},
+	"0x07": {"Common.0x07", "EC (%s) Outdoor Humidity", "%"},
+	"0x08": {"Common.0x08", "EC (%s) Abs Pressure",     "inHg"},
+	"0x09": {"Common.0x09", "EC (%s) Rel Pressure",     "inHg"},
+	"0x0a": {"Common.0x0a", "EC (%s) Wind Direction",   "°"},
+	"0x0b": {"Common.0x0b", "EC (%s) Wind Speed",       "mph"},
+	"0x0c": {"Common.0x0c", "EC (%s) Gust Speed",       "mph"},
+	"0x0d": {"Common.0x0d", "EC (%s) Rain Event",       "in"},
+	"0x0e": {"Common.0x0e", "EC (%s) Rain Rate",        "in/hr"},
+	"0x0f": {"Common.0x0f", "EC (%s) Rain Gain",        "in"},
+	"0x10": {"Common.0x10", "EC (%s) Rain Day",         "in"},
+	"0x11": {"Common.0x11", "EC (%s) Rain Week",        "in"},
+	"0x12": {"Common.0x12", "EC (%s) Rain Month",       "in"},
+	"0x13": {"Common.0x13", "EC (%s) Rain Year",        "in"},
+	"0x14": {"Common.0x14", "EC (%s) Rain Total",       "in"},
+	"0x15": {"Common.0x15", "EC (%s) Light",            "W/m²"},
+	"0x16": {"Common.0x16", "EC (%s) UV",               "W/m²"},
+	"0x17": {"Common.0x17", "EC (%s) UVI",              ""},
+	"0x19": {"Common.0x19", "EC (%s) Day Max Wind",     "mph"},
+}
+
+// NormalizeECWID converts a common_list id field to lowercase hex form
+// for lookup in ECWCommonSensors. Handles both hex-string ("0x02",
+// "0x0A") and decimal-string ("3") representations found in real
+// gateway payloads.
+func NormalizeECWID(id string) string {
+	s := strings.ToLower(strings.TrimSpace(id))
+	if strings.HasPrefix(s, "0x") {
+		return s
+	}
+	n, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return s
+	}
+	return fmt.Sprintf("0x%02x", n)
+}
+
 type ECWAPIResponse struct {
-	WH25   []ECWWH25   `json:"wh25"`
-	CHSoil []ECWCHSoil `json:"ch_soil"`
+	WH25       []ECWWH25       `json:"wh25"`
+	CHSoil     []ECWCHSoil     `json:"ch_soil"`
+	CHAisle    []ECWCHAisle    `json:"ch_aisle"`
+	CommonList []ECWCommonItem `json:"common_list"`
 }

--- a/tests/fixtures/ecowitt/ch_aisle.json
+++ b/tests/fixtures/ecowitt/ch_aisle.json
@@ -1,0 +1,4 @@
+{
+  "wh25": [{"intemp": "72.5", "unit": "F", "inhumi": "35%", "abs": "29.85 inHg", "rel": "29.85 inHg"}],
+  "ch_aisle": [{"channel": "1", "name": "", "battery": "0", "temp": "72.5", "unit": "F", "humidity": "42%"}]
+}

--- a/tests/fixtures/ecowitt/common_list.json
+++ b/tests/fixtures/ecowitt/common_list.json
@@ -1,0 +1,10 @@
+{
+  "wh25": [{"intemp": "72.5", "unit": "F", "inhumi": "35%", "abs": "29.85 inHg", "rel": "29.85 inHg"}],
+  "common_list": [
+    {"id": "0x02", "val": "79.2", "unit": "F"},
+    {"id": "0x07", "val": "65%"},
+    {"id": "0x0B", "val": "0.00mph"},
+    {"id": "0x17", "val": "3"},
+    {"id": "3",    "val": "66.4", "unit": "F"}
+  ]
+}

--- a/tests/fixtures/ecowitt/common_list_dashes.json
+++ b/tests/fixtures/ecowitt/common_list_dashes.json
@@ -1,0 +1,7 @@
+{
+  "wh25": [{"intemp": "72.5", "unit": "F", "inhumi": "35%", "abs": "29.85 inHg", "rel": "29.85 inHg"}],
+  "common_list": [
+    {"id": "0x02", "val": "--.-", "unit": "F"},
+    {"id": "0x07", "val": "--"}
+  ]
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -211,6 +211,21 @@ func (w *Watcher) PollEcoWitt(ctx context.Context, server string) {
 		dataMap["Soil."+ch.Channel] = trimTrailingPercent(ch.Humidity)
 	}
 
+	for _, ch := range apiResponse.CHAisle {
+		dataMap["Aisle."+ch.Channel+".Temp"] = ch.Temp
+		dataMap["Aisle."+ch.Channel+".Humi"] = trimTrailingPercent(ch.Humidity)
+	}
+
+	for _, item := range apiResponse.CommonList {
+		meta, ok := types.ECWCommonSensors[types.NormalizeECWID(item.ID)]
+		if !ok {
+			continue
+		}
+		if v := trimCommonVal(item.Val); v != "" {
+			dataMap[meta.TypeKey] = v
+		}
+	}
+
 	for key, value := range dataMap {
 		w.addSensorData(source, device, key, value)
 	}
@@ -365,4 +380,26 @@ func trimTrailingPercent(v string) string {
 		return v[:n-1]
 	}
 	return v
+}
+
+// trimCommonVal extracts the leading numeric portion from an EcoWitt
+// common_list val string. Returns "" for dash-placeholder values
+// ("--", "--.-") that indicate no sensor is connected. Handles the
+// range of embedded-unit formats the firmware emits: "65%", "0.00mph",
+// "29.85 inHg", "43.65 W/m2".
+func trimCommonVal(v string) string {
+	if len(v) == 0 {
+		return ""
+	}
+	if len(v) >= 2 && v[0] == '-' && v[1] == '-' {
+		return ""
+	}
+	i := 0
+	if i < len(v) && (v[i] == '-' || v[i] == '+') {
+		i++
+	}
+	for i < len(v) && ((v[i] >= '0' && v[i] <= '9') || v[i] == '.') {
+		i++
+	}
+	return v[:i]
 }

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -235,6 +235,112 @@ func TestPollEcoWitt_HappyPath(t *testing.T) {
 	assert.InDelta(t, 47.0, soil, 0.0001)
 }
 
+func TestPollEcoWitt_CHAisle(t *testing.T) {
+	t.Parallel()
+
+	db := testutil.NewTestDB(t)
+	server := fakes.FakeEcoWitt(t, "ch_aisle")
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	tempID := seedSensor(t, db, "ecowitt", u.Host, "Aisle.1.Temp")
+	humiID := seedSensor(t, db, "ecowitt", u.Host, "Aisle.1.Humi")
+
+	w := newTestWatcher(t, db)
+	w.PollEcoWitt(context.Background(), u.Host)
+
+	assert.Equal(t, 1, countSensorData(t, db, tempID))
+	assert.Equal(t, 1, countSensorData(t, db, humiID))
+
+	var temp, humi float64
+	require.NoError(t, db.QueryRow(`SELECT value FROM sensor_data WHERE sensor_id = $1`, tempID).Scan(&temp))
+	assert.InDelta(t, 72.5, temp, 0.0001)
+	require.NoError(t, db.QueryRow(`SELECT value FROM sensor_data WHERE sensor_id = $1`, humiID).Scan(&humi))
+	assert.InDelta(t, 42.0, humi, 0.0001, "percent suffix must be trimmed")
+}
+
+func TestPollEcoWitt_CommonList(t *testing.T) {
+	t.Parallel()
+
+	db := testutil.NewTestDB(t)
+	server := fakes.FakeEcoWitt(t, "common_list")
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	outTempID := seedSensor(t, db, "ecowitt", u.Host, "Common.0x02")
+	outHumiID := seedSensor(t, db, "ecowitt", u.Host, "Common.0x07")
+	windID    := seedSensor(t, db, "ecowitt", u.Host, "Common.0x0b")
+	uviID     := seedSensor(t, db, "ecowitt", u.Host, "Common.0x17")
+	dewID     := seedSensor(t, db, "ecowitt", u.Host, "Common.0x03") // decimal id "3" in fixture
+
+	w := newTestWatcher(t, db)
+	w.PollEcoWitt(context.Background(), u.Host)
+
+	for _, id := range []int{outTempID, outHumiID, windID, uviID, dewID} {
+		assert.Equalf(t, 1, countSensorData(t, db, id), "sensor %d should have one row", id)
+	}
+
+	cases := []struct {
+		id   int
+		want float64
+		name string
+	}{
+		{outTempID, 79.2, "outdoor temp"},
+		{outHumiID, 65.0, "outdoor humidity (percent stripped)"},
+		{windID, 0.0, "wind speed (mph suffix stripped)"},
+		{uviID, 3.0, "UVI (plain integer)"},
+		{dewID, 66.4, "dew point via decimal id \"3\""},
+	}
+	for _, tc := range cases {
+		var v float64
+		require.NoError(t, db.QueryRow(`SELECT value FROM sensor_data WHERE sensor_id = $1`, tc.id).Scan(&v))
+		assert.InDeltaf(t, tc.want, v, 0.0001, tc.name)
+	}
+}
+
+func TestPollEcoWitt_CommonList_SkipsDashes(t *testing.T) {
+	t.Parallel()
+
+	db := testutil.NewTestDB(t)
+	server := fakes.FakeEcoWitt(t, "common_list_dashes")
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	outTempID := seedSensor(t, db, "ecowitt", u.Host, "Common.0x02")
+	outHumiID := seedSensor(t, db, "ecowitt", u.Host, "Common.0x07")
+
+	w := newTestWatcher(t, db)
+	w.PollEcoWitt(context.Background(), u.Host)
+
+	assert.Zero(t, countSensorData(t, db, outTempID), "dash-placeholder must not write sensor data")
+	assert.Zero(t, countSensorData(t, db, outHumiID), "dash-placeholder must not write sensor data")
+}
+
+func TestTrimCommonVal(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in, want string
+	}{
+		{"79.2", "79.2"},        // clean float (temperature, separate unit field)
+		{"65%", "65"},           // percent embedded
+		{"0.00mph", "0.00"},     // unit string embedded
+		{"29.85 inHg", "29.85"}, // unit with leading space
+		{"43.65 W/m2", "43.65"}, // multi-char unit
+		{"-5.2", "-5.2"},        // negative temperature
+		{"3", "3"},              // integer (UVI)
+		{"--", ""},              // short dash placeholder
+		{"--.-", ""},            // long dash placeholder
+		{"", ""},                // empty string
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, tc.want, trimCommonVal(tc.in), "trimCommonVal(%q)", tc.in)
+	}
+}
+
 func TestTrimTrailingPercent(t *testing.T) {
 	t.Parallel()
 
@@ -316,8 +422,6 @@ func insertReadingAt(t *testing.T, db *sql.DB, sensorID int, value float64, ts t
 // ---------------------------------------------------------------------------
 
 func TestRun_StopsOnContextCancel(t *testing.T) {
-	t.Parallel()
-
 	db := testutil.NewTestDB(t)
 
 	synctest.Test(t, func(t *testing.T) {
@@ -347,8 +451,6 @@ func TestRun_StopsOnContextCancel(t *testing.T) {
 }
 
 func TestRun_RespectsRestoreInProgress(t *testing.T) {
-	t.Parallel()
-
 	db := testutil.NewTestDB(t)
 	body := testutil.MustReadFixture(t, "aci/happy.json")
 
@@ -385,8 +487,6 @@ func TestRun_RespectsRestoreInProgress(t *testing.T) {
 }
 
 func TestRun_PollsACIWhenEnabled(t *testing.T) {
-	t.Parallel()
-
 	db := testutil.NewTestDB(t)
 	seedSensor(t, db, "acinfinity", "TESTDEV", "ACI.tempC")
 	body := testutil.MustReadFixture(t, "aci/happy.json")


### PR DESCRIPTION
## What changed

Extends EcoWitt sensor support to cover two previously unsupported payload keys:

**`ch_aisle` — WH31/WN31 temperature & humidity sensors**
- Adds `ECWCHAisle` struct to `ECWAPIResponse` for JSON parsing
- Scan (`ScanEcoWittSensors`): registers one Temp and one Humi sensor per channel
- Poll (`PollEcoWitt`): writes `Aisle.<channel>.Temp` and `Aisle.<channel>.Humi` readings

**`common_list` — outdoor weather station sensors (WH32/WN32, WS80, WH65, etc.)**
- Adds `ECWCommonItem` struct and `ECWCommonSensors` lookup table (22 sensor IDs: wind, rain, UV, barometric pressure, light, outdoor T&H)
- Adds `NormalizeECWID` to handle mixed hex-string (`"0x02"`) and decimal-string (`"3"`) ID formats across firmware versions
- Adds `trimCommonVal` to strip embedded unit suffixes (`"65%"`, `"0.00mph"`, `"29.85 inHg"`) and reject dash placeholders (`"--"`, `"--.-"`) that indicate no sensor connected
- Scan: skips dash-placeholder entries so disconnected sensors don't clutter the UI
- Poll: writes `Common.<normalised-id>` readings for all registered sensors

The lookup table (`ECWCommonSensors`) is shared between the scan handler and the watcher to avoid duplication.

## Why

- WH31/WN31 multi-channel T&H sensors and outdoor stations (WH32/WN32, WS80, WH65, WS90) are common EcoWitt hardware that appeared in the gateway's `/get_livedata_info` response but were silently ignored. Users with these sensors saw nothing in the scan results.
- As an outdoor grower, I need to have more sensors available: outdoor weather info (WH32), greenhouse weather info (WH31), etc. Likely a common use case. 

## Testing

- Unit tests: new `TestPollEcoWitt_CHAisle`, `TestPollEcoWitt_CommonList`, `TestPollEcoWitt_CommonList_SkipsDashes`, `TestTrimCommonVal` — all pass (`go test ./watcher/... ./model/types/...`)
- Live hardware: GW1200 gateway + WH31/WN31 (ch_aisle) + WH51 (ch_soil) — scan correctly discovered all sensors; watcher poll confirmed via sensor graph

## Notes

`common_list` key is absent when no outdoor station is paired — the code handles this gracefully (empty slice, no-op).

---

*Generated with [Claude](https://claude.ai) (claude-sonnet-4-6) and verified against live hardware. I'm not a developer, but I've been a tech manager for decades and this passed my QA protocol.