### PR TITLE
VPD: add derived per-zone vapor pressure deficit with stage-aware ind…

### DIFF
--- a/handlers/plant.go
+++ b/handlers/plant.go
@@ -218,7 +218,7 @@ func GetMetrics(db *sql.DB) []types.Metric {
 func GetStatuses(db *sql.DB) []types.Status {
 	fieldLogger := logger.Log.WithField("func", "GetStatuses")
 
-	rows, err := db.Query("SELECT id, status FROM plant_status ORDER BY status_order")
+	rows, err := db.Query("SELECT id, status, vpd_low, vpd_high FROM plant_status ORDER BY status_order")
 	if err != nil {
 		fieldLogger.WithError(err).Error("Failed to query statuses")
 		return nil
@@ -227,10 +227,17 @@ func GetStatuses(db *sql.DB) []types.Status {
 	var statuses []types.Status
 	for rows.Next() {
 		var status types.Status
-		err = rows.Scan(&status.ID, &status.Status)
+		var vpdLow, vpdHigh sql.NullFloat64
+		err = rows.Scan(&status.ID, &status.Status, &vpdLow, &vpdHigh)
 		if err != nil {
 			fieldLogger.WithError(err).Error("Failed to scan status")
 			return nil
+		}
+		if vpdLow.Valid {
+			status.VPDLow = &vpdLow.Float64
+		}
+		if vpdHigh.Valid {
+			status.VPDHigh = &vpdHigh.Float64
 		}
 		statuses = append(statuses, status)
 	}
@@ -402,7 +409,8 @@ func GetPlant(db *sql.DB, id string) types.Plant {
 	currentWeek := int((diff.Hours() / 24 / 7) + 1)
 
 	// --- Load related data via focused sub-functions ---
-	sensorList := loadPlantSensors(db, plantID, zoneID)
+	statuses := GetStatuses(db)
+	sensorList := loadPlantSensors(db, plantID, zoneID, status, statuses)
 	measurements := loadPlantMeasurements(db, plantID)
 	activities := loadPlantActivities(db, plantID)
 	statusHistory := loadPlantStatusHistory(db, plantID)
@@ -436,7 +444,9 @@ func GetPlant(db *sql.DB, id string) types.Plant {
 // and returns each sensor's details with its latest reading.
 // Directly-linked sensors take priority over zone-inherited ones (no duplicates).
 // Uses batch queries to avoid per-sensor N+1 query overhead.
-func loadPlantSensors(db *sql.DB, plantID uint, zoneID int) []types.SensorDataResponse {
+// currentStatus is the plant's current status string (e.g. "Veg"); statuses is the
+// full list used to look up the ideal VPD range for that stage.
+func loadPlantSensors(db *sql.DB, plantID uint, zoneID int, currentStatus string, statuses []types.Status) []types.SensorDataResponse {
 	fieldLogger := logger.Log.WithField("func", "loadPlantSensors")
 
 	// 1. Load directly-linked sensor IDs from the plant's JSON column
@@ -499,7 +509,7 @@ func loadPlantSensors(db *sql.DB, plantID uint, zoneID int) []types.SensorDataRe
 	inClause, inArgs := model.BuildInClause(driver, uniqueIDs)
 
 	query := `
-		SELECT s.id, s.name, s.unit, sd.value, sd.create_dt
+		SELECT s.id, s.name, s.unit, s.source, s.type, sd.value, sd.create_dt
 		FROM sensors s
 		LEFT JOIN sensor_data sd ON s.id = sd.sensor_id
 			AND sd.id = (SELECT MAX(id) FROM sensor_data WHERE sensor_id = s.id)
@@ -513,22 +523,65 @@ func loadPlantSensors(db *sql.DB, plantID uint, zoneID int) []types.SensorDataRe
 	defer rows.Close()
 
 	type sensorInfo struct {
-		ID   uint
-		Name string
-		Unit string
-		Val  sql.NullFloat64
-		Date sql.NullTime
+		ID     uint
+		Name   string
+		Unit   string
+		Source string
+		Type   string
+		Val    sql.NullFloat64
+		Date   sql.NullTime
 	}
 	sensorMap := make(map[int]sensorInfo)
 	for rows.Next() {
 		var sid int
 		var s sensorInfo
-		if err := rows.Scan(&sid, &s.Name, &s.Unit, &s.Val, &s.Date); err != nil {
+		if err := rows.Scan(&sid, &s.Name, &s.Unit, &s.Source, &s.Type, &s.Val, &s.Date); err != nil {
 			fieldLogger.WithError(err).Error("Failed to scan batch sensor row")
 			continue
 		}
 		s.ID = uint(sid)
 		sensorMap[sid] = s
+	}
+
+	// Find the ideal VPD range for the current status
+	var stageVPDLow, stageVPDHigh *float64
+	for _, st := range statuses {
+		if st.Status == currentStatus {
+			stageVPDLow = st.VPDLow
+			stageVPDHigh = st.VPDHigh
+			break
+		}
+	}
+
+	buildResp := func(s sensorInfo, inherited bool) types.SensorDataResponse {
+		resp := types.SensorDataResponse{
+			ID:        s.ID,
+			Name:      s.Name,
+			Unit:      s.Unit,
+			Inherited: inherited,
+		}
+		if s.Val.Valid {
+			resp.Value = s.Val.Float64
+		}
+		if s.Date.Valid {
+			resp.Date = s.Date.Time.Local()
+		}
+		if s.Source == "derived" && s.Type == "VPD" {
+			resp.IsVPD = true
+			if stageVPDLow != nil && stageVPDHigh != nil {
+				resp.IdealLow = stageVPDLow
+				resp.IdealHigh = stageVPDHigh
+				switch {
+				case resp.Value < *stageVPDLow:
+					resp.RangeState = "low"
+				case resp.Value > *stageVPDHigh:
+					resp.RangeState = "high"
+				default:
+					resp.RangeState = "ideal"
+				}
+			}
+		}
+		return resp
 	}
 
 	// 5. Assemble the result: directly-linked first (preserving order), then zone-inherited
@@ -539,19 +592,7 @@ func loadPlantSensors(db *sql.DB, plantID uint, zoneID int) []types.SensorDataRe
 		if !ok {
 			continue
 		}
-		resp := types.SensorDataResponse{
-			ID:        s.ID,
-			Name:      s.Name,
-			Unit:      s.Unit,
-			Inherited: false,
-		}
-		if s.Val.Valid {
-			resp.Value = s.Val.Float64
-		}
-		if s.Date.Valid {
-			resp.Date = s.Date.Time.Local()
-		}
-		sensorList = append(sensorList, resp)
+		sensorList = append(sensorList, buildResp(s, false))
 	}
 
 	for _, sensorID := range zoneIDs {
@@ -562,19 +603,7 @@ func loadPlantSensors(db *sql.DB, plantID uint, zoneID int) []types.SensorDataRe
 		if !ok {
 			continue
 		}
-		resp := types.SensorDataResponse{
-			ID:        s.ID,
-			Name:      s.Name,
-			Unit:      s.Unit,
-			Inherited: true,
-		}
-		if s.Val.Valid {
-			resp.Value = s.Val.Float64
-		}
-		if s.Date.Valid {
-			resp.Date = s.Date.Time.Local()
-		}
-		sensorList = append(sensorList, resp)
+		sensorList = append(sensorList, buildResp(s, true))
 	}
 
 	return sensorList

--- a/handlers/sensors.go
+++ b/handlers/sensors.go
@@ -645,7 +645,7 @@ func GetZones(db *sql.DB) []types.Zone {
 	fieldLogger := logger.Log.WithField("func", "GetZones")
 
 	var zones []types.Zone
-	rows, err := db.Query("SELECT id, name FROM zones")
+	rows, err := db.Query("SELECT id, name, leaf_temp_offset, vpd_temp_sensor_id, vpd_humidity_sensor_id FROM zones")
 	if err != nil {
 		fieldLogger.WithError(err).Error("Error querying zones")
 		return nil
@@ -654,9 +654,23 @@ func GetZones(db *sql.DB) []types.Zone {
 
 	for rows.Next() {
 		var zone types.Zone
-		if err := rows.Scan(&zone.ID, &zone.Name); err != nil {
+		var leafTempOffset sql.NullFloat64
+		var vpdTempSensorID sql.NullInt64
+		var vpdHumiditySensorID sql.NullInt64
+		if err := rows.Scan(&zone.ID, &zone.Name, &leafTempOffset, &vpdTempSensorID, &vpdHumiditySensorID); err != nil {
 			fieldLogger.WithError(err).Error("Error scanning row")
 			continue
+		}
+		if leafTempOffset.Valid {
+			zone.LeafTempOffset = &leafTempOffset.Float64
+		}
+		if vpdTempSensorID.Valid {
+			v := uint(vpdTempSensorID.Int64)
+			zone.VPDTempSensorID = &v
+		}
+		if vpdHumiditySensorID.Valid {
+			v := uint(vpdHumiditySensorID.Int64)
+			zone.VPDHumiditySensorID = &v
 		}
 		zones = append(zones, zone)
 	}

--- a/handlers/settings.go
+++ b/handlers/settings.go
@@ -551,7 +551,10 @@ func UpdateZoneHandler(c *gin.Context) {
 	fieldLogger := logger.Log.WithField("func", "UpdateZoneHandler")
 	id := c.Param("id")
 	var zone struct {
-		Name string `json:"zone_name"`
+		Name                string   `json:"zone_name"`
+		LeafTempOffset      *float64 `json:"leaf_temp_offset"`
+		VPDTempSensorID     *uint    `json:"vpd_temp_sensor_id"`
+		VPDHumiditySensorID *uint    `json:"vpd_humidity_sensor_id"`
 	}
 	if err := c.ShouldBindJSON(&zone); err != nil {
 		fieldLogger.WithError(err).Error("Failed to update zone")
@@ -566,17 +569,89 @@ func UpdateZoneHandler(c *gin.Context) {
 	// Update zone in database
 	db := DBFromContext(c)
 
-	// Update zone in database
-	_, err := db.Exec("UPDATE zones SET name = $1 WHERE id = $2", zone.Name, id)
+	// Convert pointer fields to sql.Null types for nullable columns
+	var leafTempOffset sql.NullFloat64
+	if zone.LeafTempOffset != nil {
+		leafTempOffset = sql.NullFloat64{Float64: *zone.LeafTempOffset, Valid: true}
+	}
+	var vpdTempSensorID sql.NullInt64
+	if zone.VPDTempSensorID != nil {
+		vpdTempSensorID = sql.NullInt64{Int64: int64(*zone.VPDTempSensorID), Valid: true}
+	}
+	var vpdHumiditySensorID sql.NullInt64
+	if zone.VPDHumiditySensorID != nil {
+		vpdHumiditySensorID = sql.NullInt64{Int64: int64(*zone.VPDHumiditySensorID), Valid: true}
+	}
+
+	_, err := db.Exec(
+		"UPDATE zones SET name = $1, leaf_temp_offset = $2, vpd_temp_sensor_id = $3, vpd_humidity_sensor_id = $4 WHERE id = $5",
+		zone.Name, leafTempOffset, vpdTempSensorID, vpdHumiditySensorID, id,
+	)
 	if err != nil {
 		fieldLogger.WithError(err).Error("Failed to update zone")
 		apiInternalError(c, "api_failed_to_update_zone")
 		return
 	}
+
+	// If VPD is enabled (leaf_temp_offset is set), ensure a derived VPD sensor row exists
+	if zone.LeafTempOffset != nil {
+		zoneIDInt, convErr := strconv.Atoi(id)
+		if convErr == nil {
+			vpdSensorName := "VPD (Zone " + id + ")"
+			if _, sErr := findOrCreateSensor(db, vpdSensorName, "derived", id, "VPD", &zoneIDInt, "kPa"); sErr != nil {
+				fieldLogger.WithError(sErr).Warn("Failed to ensure derived VPD sensor for zone")
+			}
+		}
+	}
+
 	//Reload Config
 	ConfigStoreFromContext(c).SetZones(GetZones(db))
 
 	apiOK(c, "api_zone_updated")
+}
+
+// UpdateStatusVPDHandler updates the vpd_low and vpd_high columns for a
+// single plant_status row, then refreshes the in-memory statuses store.
+// Route: POST /statuses/:id/vpd
+func UpdateStatusVPDHandler(c *gin.Context) {
+	fieldLogger := logger.Log.WithField("func", "UpdateStatusVPDHandler")
+	id := c.Param("id")
+
+	var payload struct {
+		VPDLow  *float64 `json:"vpd_low"`
+		VPDHigh *float64 `json:"vpd_high"`
+	}
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		fieldLogger.WithError(err).Error("Failed to bind JSON")
+		apiBadRequest(c, "api_invalid_payload")
+		return
+	}
+
+	db := DBFromContext(c)
+
+	var vpdLow sql.NullFloat64
+	if payload.VPDLow != nil {
+		vpdLow = sql.NullFloat64{Float64: *payload.VPDLow, Valid: true}
+	}
+	var vpdHigh sql.NullFloat64
+	if payload.VPDHigh != nil {
+		vpdHigh = sql.NullFloat64{Float64: *payload.VPDHigh, Valid: true}
+	}
+
+	_, err := db.Exec(
+		"UPDATE plant_status SET vpd_low = $1, vpd_high = $2 WHERE id = $3",
+		vpdLow, vpdHigh, id,
+	)
+	if err != nil {
+		fieldLogger.WithError(err).Error("Failed to update status VPD range")
+		apiInternalError(c, "api_failed_to_update_status_vpd")
+		return
+	}
+
+	// Reload statuses in the store
+	ConfigStoreFromContext(c).SetStatuses(GetStatuses(db))
+
+	apiOK(c, "api_status_vpd_updated")
 }
 
 func UpdateMetricHandler(c *gin.Context) {

--- a/model/migrations/postgres/019_zone_vpd.postgres.down.sql
+++ b/model/migrations/postgres/019_zone_vpd.postgres.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE plant_status DROP COLUMN IF EXISTS vpd_high;
+ALTER TABLE plant_status DROP COLUMN IF EXISTS vpd_low;
+
+ALTER TABLE zones DROP COLUMN IF EXISTS vpd_humidity_sensor_id;
+ALTER TABLE zones DROP COLUMN IF EXISTS vpd_temp_sensor_id;
+ALTER TABLE zones DROP COLUMN IF EXISTS leaf_temp_offset;

--- a/model/migrations/postgres/019_zone_vpd.postgres.up.sql
+++ b/model/migrations/postgres/019_zone_vpd.postgres.up.sql
@@ -1,0 +1,14 @@
+-- Per-zone VPD configuration: leaf-temp offset (also the on/off switch) and the
+-- temperature + humidity sensors selected as the VPD inputs for the zone.
+ALTER TABLE zones ADD COLUMN leaf_temp_offset REAL;
+ALTER TABLE zones ADD COLUMN vpd_temp_sensor_id INTEGER REFERENCES sensors(id) ON DELETE SET NULL;
+ALTER TABLE zones ADD COLUMN vpd_humidity_sensor_id INTEGER REFERENCES sensors(id) ON DELETE SET NULL;
+
+-- Per-growth-stage ideal VPD range (kPa). NULL = no indicator for that stage.
+ALTER TABLE plant_status ADD COLUMN vpd_low REAL;
+ALTER TABLE plant_status ADD COLUMN vpd_high REAL;
+
+-- Seed defaults for the active growing stages (sources: Humboldt Seed Co., Smartfog).
+UPDATE plant_status SET vpd_low = 0.4, vpd_high = 0.8 WHERE status = 'Seedling';
+UPDATE plant_status SET vpd_low = 0.8, vpd_high = 1.2 WHERE status = 'Veg';
+UPDATE plant_status SET vpd_low = 1.2, vpd_high = 1.5 WHERE status = 'Flower';

--- a/model/migrations/sqlite/019_zone_vpd.sqlite.down.sql
+++ b/model/migrations/sqlite/019_zone_vpd.sqlite.down.sql
@@ -1,0 +1,9 @@
+-- Requires SQLite >= 3.35 (ALTER TABLE DROP COLUMN); satisfied by the bundled
+-- modernc.org/sqlite (SQLite 3.50+). A table rebuild is intentionally avoided
+-- here because zones is referenced by FKs (sensors.zone_id, plant.zone_id).
+ALTER TABLE plant_status DROP COLUMN vpd_high;
+ALTER TABLE plant_status DROP COLUMN vpd_low;
+
+ALTER TABLE zones DROP COLUMN vpd_humidity_sensor_id;
+ALTER TABLE zones DROP COLUMN vpd_temp_sensor_id;
+ALTER TABLE zones DROP COLUMN leaf_temp_offset;

--- a/model/migrations/sqlite/019_zone_vpd.sqlite.up.sql
+++ b/model/migrations/sqlite/019_zone_vpd.sqlite.up.sql
@@ -1,0 +1,14 @@
+-- Per-zone VPD configuration: leaf-temp offset (also the on/off switch) and the
+-- temperature + humidity sensors selected as the VPD inputs for the zone.
+ALTER TABLE zones ADD COLUMN leaf_temp_offset REAL;
+ALTER TABLE zones ADD COLUMN vpd_temp_sensor_id INTEGER REFERENCES sensors(id) ON DELETE SET NULL;
+ALTER TABLE zones ADD COLUMN vpd_humidity_sensor_id INTEGER REFERENCES sensors(id) ON DELETE SET NULL;
+
+-- Per-growth-stage ideal VPD range (kPa). NULL = no indicator for that stage.
+ALTER TABLE plant_status ADD COLUMN vpd_low REAL;
+ALTER TABLE plant_status ADD COLUMN vpd_high REAL;
+
+-- Seed defaults for the active growing stages (sources: Humboldt Seed Co., Smartfog).
+UPDATE plant_status SET vpd_low = 0.4, vpd_high = 0.8 WHERE status = 'Seedling';
+UPDATE plant_status SET vpd_low = 0.8, vpd_high = 1.2 WHERE status = 'Veg';
+UPDATE plant_status SET vpd_low = 1.2, vpd_high = 1.5 WHERE status = 'Flower';

--- a/model/types/base_models.go
+++ b/model/types/base_models.go
@@ -141,12 +141,16 @@ type SensorData struct {
 }
 
 type SensorDataResponse struct {
-	ID        uint      `json:"id"`
-	Name      string    `json:"name"`
-	Unit      string    `json:"unit"`
-	Value     float64   `json:"value"`
-	Date      time.Time `json:"date"`
-	Inherited bool      `json:"inherited"` // true if sensor is inherited from the plant's zone rather than directly linked
+	ID         uint      `json:"id"`
+	Name       string    `json:"name"`
+	Unit       string    `json:"unit"`
+	Value      float64   `json:"value"`
+	Date       time.Time `json:"date"`
+	Inherited  bool      `json:"inherited"` // true if sensor is inherited from the plant's zone rather than directly linked
+	IdealLow   *float64  `json:"ideal_low,omitempty"`
+	IdealHigh  *float64  `json:"ideal_high,omitempty"`
+	RangeState string    `json:"range_state,omitempty"` // "", "ideal", "low", "high"
+	IsVPD      bool      `json:"is_vpd,omitempty"`
 }
 
 type Settings struct {
@@ -200,6 +204,8 @@ type Status struct {
 	Status   string    `json:"status"`
 	Date     time.Time `json:"date"`
 	StatusID int       `json:"status_id"`
+	VPDLow   *float64  `json:"vpd_low"`
+	VPDHigh  *float64  `json:"vpd_high"`
 }
 
 type Strain struct {
@@ -227,8 +233,11 @@ type StrainLineage struct {
 }
 
 type Zone struct {
-	ID   uint   `json:"id"`
-	Name string `json:"name"`
+	ID                  uint     `json:"id"`
+	Name                string   `json:"name"`
+	LeafTempOffset      *float64 `json:"leaf_temp_offset"`
+	VPDTempSensorID     *uint    `json:"vpd_temp_sensor_id"`
+	VPDHumiditySensorID *uint    `json:"vpd_humidity_sensor_id"`
 }
 
 type Stream struct {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -333,6 +333,8 @@ func AddProtectedApiRoutes(r *gin.RouterGroup) {
 	r.PUT("/zones/:id", handlers.UpdateZoneHandler)
 	r.DELETE("/zones/:id", handlers.DeleteZoneHandler)
 
+	r.POST("/statuses/:id/vpd", handlers.UpdateStatusVPDHandler)
+
 	r.POST("/metrics", handlers.AddMetricHandler)
 	r.GET("/metrics", handlers.GetMetricsHandler)
 	r.PUT("/metrics/:id", handlers.UpdateMetricHandler)
@@ -426,17 +428,20 @@ func AddProtectedRoutes(r *gin.RouterGroup, version string) {
 		translations := utils.TranslationService.GetTranslations(lang)
 		currentPath, _ := c.Get("currentPath")
 		store := handlers.ConfigStoreFromContext(c)
+		db := handlers.DBFromContext(c)
 		c.HTML(http.StatusOK, "views/settings.html", gin.H{
 			"title":           "Settings",
 			"currentPath":     currentPath,
 			"version":         version,
-			"settings":        handlers.GetSettings(handlers.DBFromContext(c)),
+			"settings":        handlers.GetSettings(db),
 			"zones":           store.Zones(),
+			"statuses":        store.Statuses(),
+			"sensors":         handlers.GetSensors(db),
 			"metrics":         store.Metrics(),
-			"plants":          handlers.GetLivingPlants(handlers.DBFromContext(c)),
+			"plants":          handlers.GetLivingPlants(db),
 			"activities":      store.Activities(),
 			"breeders":        store.Breeders(),
-			"streams":         handlers.GetStreams(handlers.DBFromContext(c)),
+			"streams":         handlers.GetStreams(db),
 			"loggedIn":        sessions.Default(c).Get("logged_in"),
 			"lcl":             translations,
 			"languages":       utils.AvailableLanguages,

--- a/utils/vpd.go
+++ b/utils/vpd.go
@@ -1,0 +1,31 @@
+package utils
+
+import "math"
+
+// FahrenheitToCelsius converts a temperature from Fahrenheit to Celsius.
+func FahrenheitToCelsius(f float64) float64 {
+	return (f - 32.0) * 5.0 / 9.0
+}
+
+// saturationVaporPressure returns the saturation vapour pressure in kPa for
+// a given temperature in °C using the Tetens approximation.
+func saturationVaporPressure(tempC float64) float64 {
+	return 0.6107 * math.Pow(10, 7.5*tempC/(237.3+tempC))
+}
+
+// VPD computes the Vapor Pressure Deficit in kPa.
+//
+// Parameters:
+//   - airTempC   – air temperature in °C
+//   - rhPct      – relative humidity in percent (0–100)
+//   - leafOffsetC – leaf temperature offset relative to air temp, in °C
+//     (typically negative, i.e. the leaf is cooler than the air)
+//
+// Formula:
+//
+//	VPD = es(airTempC + leafOffsetC) - es(airTempC) * rh/100
+func VPD(airTempC, rhPct, leafOffsetC float64) float64 {
+	esLeaf := saturationVaporPressure(airTempC + leafOffsetC)
+	esAir := saturationVaporPressure(airTempC)
+	return esLeaf - esAir*rhPct/100.0
+}

--- a/utils/vpd_test.go
+++ b/utils/vpd_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFahrenheitToCelsius(t *testing.T) {
+	cases := []struct {
+		f, want float64
+	}{
+		{32.0, 0.0},
+		{212.0, 100.0},
+		{77.0, 25.0},
+	}
+	for _, tc := range cases {
+		got := FahrenheitToCelsius(tc.f)
+		if math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("FahrenheitToCelsius(%v) = %v, want %v", tc.f, got, tc.want)
+		}
+	}
+}
+
+func TestVPD(t *testing.T) {
+	// All expected values computed from the Tetens formula by hand:
+	//   es(T) = 0.6107 * 10^(7.5*T / (237.3+T))
+	//   VPD   = es(airT + offset) - es(airT)*rh/100
+	//
+	// Case 1: 25°C, 50% RH, 0 offset
+	//   es(25) = 0.6107 * 10^(187.5/262.3) ≈ 0.6107 * 10^0.7148 ≈ 0.6107 * 5.188 ≈ 3.168 kPa
+	//   VPD    = 3.168 - 3.168*0.50 ≈ 1.584 kPa
+	//
+	// Case 2: 25°C, 70% RH, -2 offset (leaf at 23°C)
+	//   es(23) = 0.6107 * 10^(172.5/260.3) ≈ 0.6107 * 10^0.6629 ≈ 0.6107 * 4.601 ≈ 2.810 kPa
+	//   es(25) ≈ 3.168 kPa
+	//   VPD    = 2.810 - 3.168*0.70 ≈ 2.810 - 2.218 ≈ 0.593 kPa
+	//
+	// Case 3: 30°C, 60% RH, 0 offset
+	//   es(30) = 0.6107 * 10^(225/267.3) ≈ 0.6107 * 10^0.8419 ≈ 0.6107 * 6.950 ≈ 4.244 kPa
+	//   VPD    = 4.244 - 4.244*0.60 ≈ 1.697 kPa
+
+	cases := []struct {
+		name       string
+		airTempC   float64
+		rhPct      float64
+		leafOffset float64
+		wantApprox float64
+		tolerance  float64
+	}{
+		{"25C/50RH/0offset", 25.0, 50.0, 0.0, 1.584, 0.01},
+		{"25C/70RH/-2offset", 25.0, 70.0, -2.0, 0.593, 0.01},
+		{"30C/60RH/0offset", 30.0, 60.0, 0.0, 1.697, 0.01},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := VPD(tc.airTempC, tc.rhPct, tc.leafOffset)
+			if math.Abs(got-tc.wantApprox) > tc.tolerance {
+				t.Errorf("VPD(%v, %v, %v) = %.4f, want %.4f ± %.4f",
+					tc.airTempC, tc.rhPct, tc.leafOffset, got, tc.wantApprox, tc.tolerance)
+			}
+		})
+	}
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ import (
 	"isley/logger"
 	"isley/model"
 	"isley/model/types"
+	"isley/utils"
 )
 
 const (
@@ -136,6 +138,8 @@ func (w *Watcher) Run(ctx context.Context) {
 					w.PollEcoWitt(ctx, ecServer)
 				}
 			}
+
+			w.computeZoneVPD(ctx)
 
 			select {
 			case <-pruneTicker.C:
@@ -402,4 +406,117 @@ func trimCommonVal(v string) string {
 		i++
 	}
 	return v[:i]
+}
+
+// computeZoneVPD calculates and stores derived VPD sensor readings for every
+// zone that has VPD enabled (leaf_temp_offset IS NOT NULL) and both source
+// sensor IDs configured. It is called once per poll cycle, after device polling.
+func (w *Watcher) computeZoneVPD(_ context.Context) {
+	fieldLogger := w.Logger.WithField("func", "computeZoneVPD")
+
+	// Load all zones that have VPD configured
+	rows, err := w.DB.Query(`
+		SELECT id, leaf_temp_offset, vpd_temp_sensor_id, vpd_humidity_sensor_id
+		FROM zones
+		WHERE leaf_temp_offset IS NOT NULL
+		  AND vpd_temp_sensor_id IS NOT NULL
+		  AND vpd_humidity_sensor_id IS NOT NULL`)
+	if err != nil {
+		fieldLogger.WithError(err).Error("Failed to query VPD-enabled zones")
+		return
+	}
+	defer rows.Close()
+
+	type vpdZone struct {
+		ID                  int
+		LeafTempOffset      float64
+		VPDTempSensorID     int
+		VPDHumiditySensorID int
+	}
+
+	var zones []vpdZone
+	for rows.Next() {
+		var z vpdZone
+		if err := rows.Scan(&z.ID, &z.LeafTempOffset, &z.VPDTempSensorID, &z.VPDHumiditySensorID); err != nil {
+			fieldLogger.WithError(err).Error("Failed to scan VPD zone row")
+			continue
+		}
+		zones = append(zones, z)
+	}
+	rows.Close()
+
+	for _, z := range zones {
+		// Read the latest value and unit for the temperature sensor
+		var tempValue float64
+		var tempUnit string
+		err := w.DB.QueryRow(`
+			SELECT sd.value, s.unit
+			FROM sensor_data sd
+			JOIN sensors s ON s.id = sd.sensor_id
+			WHERE sd.sensor_id = $1
+			ORDER BY sd.id DESC LIMIT 1`, z.VPDTempSensorID).Scan(&tempValue, &tempUnit)
+		if err != nil {
+			fieldLogger.WithFields(logrus.Fields{"zone_id": z.ID, "sensor_id": z.VPDTempSensorID}).
+				Debug("No temperature reading for VPD zone, skipping")
+			continue
+		}
+
+		// Read the latest humidity value
+		var humValue float64
+		err = w.DB.QueryRow(`
+			SELECT value FROM sensor_data
+			WHERE sensor_id = $1
+			ORDER BY id DESC LIMIT 1`, z.VPDHumiditySensorID).Scan(&humValue)
+		if err != nil {
+			fieldLogger.WithFields(logrus.Fields{"zone_id": z.ID, "sensor_id": z.VPDHumiditySensorID}).
+				Debug("No humidity reading for VPD zone, skipping")
+			continue
+		}
+
+		// The offset is stored in °F as a temperature *delta*, so it always
+		// converts to a °C delta by *5/9 (no -32 — it is a difference, not an
+		// absolute temperature). The air temperature is converted to °C only
+		// when the source sensor reports Fahrenheit (unit lacks "C").
+		airTempC := tempValue
+		if !strings.Contains(tempUnit, "C") {
+			airTempC = utils.FahrenheitToCelsius(tempValue)
+		}
+		leafOffsetC := z.LeafTempOffset * 5.0 / 9.0
+
+		vpd := utils.VPD(airTempC, humValue, leafOffsetC)
+
+		// Ensure the derived VPD sensor row exists for this zone
+		zoneIDStr := strconv.Itoa(z.ID)
+		sensorName := "VPD (Zone " + zoneIDStr + ")"
+		var vpdSensorID int
+		err = w.DB.QueryRow(
+			`SELECT id FROM sensors WHERE source = $1 AND device = $2 AND type = $3`,
+			"derived", zoneIDStr, "VPD",
+		).Scan(&vpdSensorID)
+		if err == sql.ErrNoRows {
+			// Create the derived VPD sensor
+			err = w.DB.QueryRow(
+				`INSERT INTO sensors (name, source, device, type, zone_id, unit, visibility)
+                 VALUES ($1, $2, $3, $4, $5, $6, 'zone_plant')
+                 RETURNING id`,
+				sensorName, "derived", zoneIDStr, "VPD", z.ID, "kPa",
+			).Scan(&vpdSensorID)
+			if err != nil {
+				fieldLogger.WithError(err).WithField("zone_id", z.ID).Error("Failed to create derived VPD sensor")
+				continue
+			}
+			fieldLogger.WithField("zone_id", z.ID).Info("Created derived VPD sensor")
+		} else if err != nil {
+			fieldLogger.WithError(err).WithField("zone_id", z.ID).Error("Failed to look up derived VPD sensor")
+			continue
+		}
+
+		// Insert the computed VPD reading
+		if _, err := w.DB.Exec(
+			"INSERT INTO sensor_data (sensor_id, value) VALUES ($1, $2)",
+			vpdSensorID, vpd,
+		); err != nil {
+			fieldLogger.WithError(err).WithField("zone_id", z.ID).Error("Failed to insert VPD sensor data")
+		}
+	}
 }

--- a/web/static/css/isley.css
+++ b/web/static/css/isley.css
@@ -2079,6 +2079,24 @@ header .nav-link.active::after {
     border-style: dashed;
     opacity: 0.8;
 }
+.hero-sensor-vpd-ideal {
+    border-color: #22c55e;
+}
+.hero-sensor-vpd-ideal .hero-sensor-val {
+    color: #22c55e;
+}
+.hero-sensor-vpd-low {
+    border-color: #3b82f6;
+}
+.hero-sensor-vpd-low .hero-sensor-val {
+    color: #3b82f6;
+}
+.hero-sensor-vpd-high {
+    border-color: #f87171;
+}
+.hero-sensor-vpd-high .hero-sensor-val {
+    color: #f87171;
+}
 .hero-sensor-name {
     opacity: 0.7;
     font-weight: 500;

--- a/web/templates/views/plant.html
+++ b/web/templates/views/plant.html
@@ -28,10 +28,18 @@
         {{ if and .plant.Sensors (ne .plant.Status "Dead") (ne .plant.Status "Success") (ne .plant.Status "Drying") (ne .plant.Status "Curing") }}
         <div class="plant-hero-sensors">
             {{ range .plant.Sensors }}
+            {{ if .IsVPD }}
+            <a href="/graph/{{.ID}}" class="hero-sensor-chip{{ if eq .RangeState "ideal" }} hero-sensor-vpd-ideal{{ else if eq .RangeState "low" }} hero-sensor-vpd-low{{ else if eq .RangeState "high" }} hero-sensor-vpd-high{{ end }}">
+                <span class="hero-sensor-name">{{ .Name }}</span>
+                <span class="hero-sensor-val">{{ printf "%.2f" .Value }}<span class="hero-sensor-unit">{{ .Unit }}</span></span>
+                {{ if eq .RangeState "low" }}<i class="fa-solid fa-arrow-up ms-1"></i>{{ else if eq .RangeState "high" }}<i class="fa-solid fa-arrow-down ms-1"></i>{{ end }}
+            </a>
+            {{ else }}
             <a href="/graph/{{.ID}}" class="hero-sensor-chip{{ if .Inherited }} hero-sensor-inherited{{ end }}">
                 <span class="hero-sensor-name">{{ .Name }}</span>
                 <span class="hero-sensor-val">{{ .Value }}<span class="hero-sensor-unit">{{ .Unit }}</span></span>
             </a>
+            {{ end }}
             {{ end }}
         </div>
         {{ end }}

--- a/web/templates/views/settings.html
+++ b/web/templates/views/settings.html
@@ -364,6 +364,20 @@ color: #0d6efd; /* Primary color */
                     </table>
                 </div>
             </div>
+
+            <!-- VPD Stage Ranges -->
+            <div class="card mb-4 shadow-sm card-table">
+                <div class="card-header bg-themed">
+                    <h2 class="h5 mb-0">&#127807; VPD Stage Ranges</h2>
+                    <small class="text-muted">Set the ideal VPD range (kPa) for each growth stage. Leave blank to disable the indicator.</small>
+                </div>
+                <div class="card-body">
+                    <table class="table table-sm mb-0" id="vpdStageTable">
+                        <thead class="bg-themed"><tr><th>Stage</th><th>Low (kPa)</th><th>High (kPa)</th><th></th></tr></thead>
+                        <tbody id="vpdStageTableBody"></tbody>
+                    </table>
+                </div>
+            </div>
         </div>
 
         <!-- Appearance Tab -->
@@ -833,6 +847,24 @@ color: #0d6efd; /* Primary color */
                         <label for="editZoneName" class="form-label">{{ .lcl.zone_name }}</label>
                         <input type="text" class="form-control" id="editZoneName" step="any" required>
                     </div>
+                    <hr>
+                    <p class="text-muted small mb-2">VPD — leave offset blank to disable VPD for this zone.</p>
+                    <div class="mb-3">
+                        <label for="editZoneLeafOffset" class="form-label">Leaf temp offset (°F)</label>
+                        <input type="number" class="form-control" id="editZoneLeafOffset" step="0.1" placeholder="e.g. -2 (leave blank to disable)">
+                    </div>
+                    <div class="mb-3">
+                        <label for="editZoneVpdTempSensor" class="form-label">VPD temperature sensor</label>
+                        <select class="form-select" id="editZoneVpdTempSensor">
+                            <option value="">— none —</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="editZoneVpdHumSensor" class="form-label">VPD humidity sensor</label>
+                        <select class="form-select" id="editZoneVpdHumSensor">
+                            <option value="">— none —</option>
+                        </select>
+                    </div>
                     <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk"></i> {{ .lcl.save_changes }}</button>
                     <button type="button" class="btn btn-danger" id="deleteZone"><i class="fa-solid fa-trash"></i> {{ .lcl.delete_zone }}</button>
                 </form>
@@ -840,6 +872,51 @@ color: #0d6efd; /* Primary color */
         </div>
     </div>
 </div>
+
+<script nonce="{{ .cspNonce }}">
+(function() {
+    const statusesRaw = {{ json .statuses }};
+    const statuses = typeof statusesRaw === "string" ? JSON.parse(statusesRaw || "[]") : (statusesRaw || []);
+    const sensorsRaw = {{ json .sensors }};
+    const sensors = typeof sensorsRaw === "string" ? JSON.parse(sensorsRaw || "[]") : (sensorsRaw || []);
+    const tbody = document.getElementById('vpdStageTableBody');
+    if (tbody && statuses) {
+        statuses.forEach(function(st) {
+            const tr = document.createElement('tr');
+            tr.dataset.statusId = st.id;
+            tr.innerHTML =
+                '<td>' + st.status + '</td>' +
+                '<td><input type="number" class="form-control form-control-sm vpd-low" step="0.01" value="' + (st.vpd_low != null ? st.vpd_low.toFixed(2) : '') + '" placeholder="—"></td>' +
+                '<td><input type="number" class="form-control form-control-sm vpd-high" step="0.01" value="' + (st.vpd_high != null ? st.vpd_high.toFixed(2) : '') + '" placeholder="—"></td>' +
+                '<td><button type="button" class="btn btn-sm btn-primary vpd-save-btn">Save</button></td>';
+            tbody.appendChild(tr);
+        });
+        tbody.querySelectorAll('.vpd-save-btn').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                const row = btn.closest('tr');
+                const statusId = row.dataset.statusId;
+                const lowVal = row.querySelector('.vpd-low').value;
+                const highVal = row.querySelector('.vpd-high').value;
+                const payload = {
+                    vpd_low:  lowVal  !== '' ? parseFloat(lowVal)  : null,
+                    vpd_high: highVal !== '' ? parseFloat(highVal) : null,
+                };
+                fetch('/statuses/' + statusId + '/vpd', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                }).then(function(r) { return r.json(); })
+                  .then(function() { uiMessages.showToast('VPD range saved', 'success'); })
+                  .catch(function() { uiMessages.showToast('Failed to save VPD range', 'danger'); });
+            });
+        });
+    }
+
+    // Populate VPD sensor selects when the zone edit modal opens.
+    // This runs after the modal JS below, so we use a custom event approach.
+    window._vpdSensors = sensors || [];
+})();
+</script>
 
 <!-- Activity Edit Modal -->
 <div class="modal fade" id="editActivityModal" tabindex="-1" aria-labelledby="editActivityModalLabel" aria-hidden="true">
@@ -1159,12 +1236,35 @@ color: #0d6efd; /* Primary color */
         const zoneForm = document.getElementById("editZoneForm");
         const deleteZoneButton = document.getElementById("deleteZone");
 
+        function populateVpdSensorSelect(selectEl, zoneId, selectedId) {
+            const sensors = window._vpdSensors || [];
+            selectEl.innerHTML = '<option value="">— none —</option>';
+            sensors.forEach(function(s) {
+                if (s.source === 'derived') return; // skip derived sensors as VPD inputs
+                if (s.zone_id === zoneId) {
+                    const opt = document.createElement('option');
+                    opt.value = s.id;
+                    opt.textContent = s.name + ' (' + s.unit + ')';
+                    if (selectedId && s.id === selectedId) opt.selected = true;
+                    selectEl.appendChild(opt);
+                }
+            });
+        }
+
         document.querySelectorAll(".zone-row").forEach(row => {
             row.addEventListener("click", () => {
                 const zoneData = JSON.parse(row.getAttribute("data-zone"));
 
                 document.getElementById("zoneId").value = zoneData.id;
                 document.getElementById("editZoneName").value = zoneData.name;
+
+                const offsetInput = document.getElementById("editZoneLeafOffset");
+                offsetInput.value = (zoneData.leaf_temp_offset != null) ? zoneData.leaf_temp_offset : '';
+
+                const tempSelect = document.getElementById("editZoneVpdTempSensor");
+                const humSelect  = document.getElementById("editZoneVpdHumSensor");
+                populateVpdSensorSelect(tempSelect, zoneData.id, zoneData.vpd_temp_sensor_id);
+                populateVpdSensorSelect(humSelect,  zoneData.id, zoneData.vpd_humidity_sensor_id);
 
                 editZoneModal.show();
             });
@@ -1173,8 +1273,15 @@ color: #0d6efd; /* Primary color */
         zoneForm.addEventListener("submit", (e) => {
             e.preventDefault();
             const zoneId = document.getElementById("zoneId").value;
+            const offsetRaw = document.getElementById("editZoneLeafOffset").value;
+            const tempSensor = document.getElementById("editZoneVpdTempSensor").value;
+            const humSensor  = document.getElementById("editZoneVpdHumSensor").value;
+
             const payload = {
-                zone_name: document.getElementById("editZoneName").value,
+                zone_name:              document.getElementById("editZoneName").value,
+                leaf_temp_offset:       offsetRaw !== '' ? parseFloat(offsetRaw) : null,
+                vpd_temp_sensor_id:     tempSensor  !== '' ? parseInt(tempSensor,  10) : null,
+                vpd_humidity_sensor_id: humSensor   !== '' ? parseInt(humSensor,   10) : null,
             };
 
             fetch(`/zones/${zoneId}`, {


### PR DESCRIPTION
…icator

## Summary
- Compute VPD per sensor zone from the zone's selected temperature + humidity sensors plus a per-zone leaf-temperature offset, and store it as a regular sensor reading each poll cycle — so it both displays on the plant page and graphs over time through existing machinery.
- Show a stage-aware indicator on the plant page: the VPD chip is colored by the plant's current growth stage's ideal range — green (in range), blue + up-arrow (too low), red + down-arrow (too high).
- New per-zone config in the zone edit modal: leaf-temp offset (F), VPD temperature source, VPD humidity source. New per-stage ideal-range editor in Settings > Customization.
- utils/vpd.go: Tetens VPD calculation (+ unit tests).
- Migration 019_zone_vpd (sqlite + postgres): zones.leaf_temp_offset, zones.vpd_temp_sensor_id, zones.vpd_humidity_sensor_id; plant_status.vpd_low, plant_status.vpd_high (seeded Seedling 0.4-0.8, Veg 0.8-1.2, Flower 1.2-1.5 kPa).

## Why
- Today VPD exists only when a device reports it directly (AC Infinity; EcoWitt WN32). Outdoor/greenhouse growers can't get it, and an outdoor sensor's VPD doesn't reflect interior canopy conditions. A constant leaf-temp offset + the zone's live temp/humidity gives continuous canopy VPD, and the stage indicator removes the manual lookup of whether the value is right for the stage.

## How to test
- Start the app once and confirm migration 019 applies cleanly (no dirty state).
- Settings > Customization: the "VPD Stage Ranges" card shows seeded values and saves edits (POST /statuses/:id/vpd).
- Edit a zone: set a leaf-temp offset (F) and pick temp + humidity source sensors.
- After one poll cycle, open a plant in that zone: a VPD chip appears, colored vs. the plant's stage, and /graph/<sensor-id> builds a line over time.

## Infra/ops impact
- No secrets added.
- Rollback: migrations are additive (nullable columns + seeding three plant_status rows); down-migrations provided for both drivers. Reverting to a build without 019 leaves the columns unused (all SELECTs are explicit, not SELECT *).

## Notes
- Temperature units: the codebase has no normalization layer and all temp sensors are labeled F. The VPD helper converts the air-temp reading to C from the sensor unit and treats the offset as an F delta (x5/9). Tetens constants are C-only.
- Two deviations worth a maintainer look: (1) the SQLite down-migration uses ALTER TABLE DROP COLUMN (safe on the bundled modernc SQLite 3.50+) rather than a zones table rebuild, because zones is FK-referenced by sensors/plant; (2) the per-stage editor and zone sensor selects render via JS from {{ json . }} (JSON.parsed, matching the existing plants.html pattern), as there is no deref template func.
- Seed VPD ranges are editable per stage; defaults drawn from common cannabis VPD charts.