### PR TITLE
EcoWitt: add ch_ec (WH52) soil sensor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- EcoWitt `ch_ec` support: WH52 soil sensor reporting soil moisture, soil
+  temperature, and electrical conductivity (converted to mS/cm), registered
+  per channel.
 
 ### Changed
 

--- a/handlers/sensors.go
+++ b/handlers/sensors.go
@@ -566,6 +566,19 @@ func ScanEcoWittSensors(c *gin.Context) {
 			"EC ("+device+") Ch"+ch.Channel+" Humi", input.ZoneID, "%")
 	}
 
+	for _, ch := range apiResponse.CHEc {
+		tempUnit := "°F"
+		if ch.Unit == "C" {
+			tempUnit = "°C"
+		}
+		checkInsertSensor(db, source, device, "SoilEC."+ch.Channel+".Moisture",
+			"EC ("+device+") Ch"+ch.Channel+" Soil Moisture", input.ZoneID, "%")
+		checkInsertSensor(db, source, device, "SoilEC."+ch.Channel+".Temp",
+			"EC ("+device+") Ch"+ch.Channel+" Soil Temp", input.ZoneID, tempUnit)
+		checkInsertSensor(db, source, device, "SoilEC."+ch.Channel+".EC",
+			"EC ("+device+") Ch"+ch.Channel+" Soil EC", input.ZoneID, "mS/cm")
+	}
+
 	for _, item := range apiResponse.CommonList {
 		meta, ok := types.ECWCommonSensors[types.NormalizeECWID(item.ID)]
 		if !ok {

--- a/model/types/ecowitt_models.go
+++ b/model/types/ecowitt_models.go
@@ -30,6 +30,24 @@ type ECWCHAisle struct {
 	Humidity string `json:"humidity"`
 }
 
+// ECWCHEc holds one channel of a WH52 soil sensor, reported by the gateway
+// in the ch_ec array (added in EcoWitt local API v1.0.6). Unlike the
+// moisture-only WH51 (ch_soil), the WH52 also reports soil temperature and
+// electrical conductivity. The Humidity field is soil moisture (named
+// "humidity" in the payload, matching ch_soil/ch_aisle). EC carries its unit
+// inline (e.g. "470 uS/cm"). Battery/Voltage are parsed but not registered as
+// sensors, matching how ch_soil/ch_aisle are handled.
+type ECWCHEc struct {
+	Channel  string `json:"channel"`
+	Name     string `json:"name"`
+	Battery  string `json:"battery"`
+	Voltage  string `json:"voltage"`
+	Humidity string `json:"humidity"`
+	Temp     string `json:"temp"`
+	Unit     string `json:"unit"`
+	EC       string `json:"ec"`
+}
+
 type ECWCommonItem struct {
 	ID      string `json:"id"`
 	Val     string `json:"val"`
@@ -90,5 +108,6 @@ type ECWAPIResponse struct {
 	WH25       []ECWWH25       `json:"wh25"`
 	CHSoil     []ECWCHSoil     `json:"ch_soil"`
 	CHAisle    []ECWCHAisle    `json:"ch_aisle"`
+	CHEc       []ECWCHEc       `json:"ch_ec"`
 	CommonList []ECWCommonItem `json:"common_list"`
 }

--- a/tests/fixtures/ecowitt/ch_ec.json
+++ b/tests/fixtures/ecowitt/ch_ec.json
@@ -1,0 +1,4 @@
+{
+  "wh25": [{"intemp": "72.5", "unit": "F", "inhumi": "35%", "abs": "29.85 inHg", "rel": "29.85 inHg"}],
+  "ch_ec": [{"channel": "2", "name": "", "battery": "3", "voltage": "1.34", "humidity": "28%", "temp": "78.1", "unit": "F", "ec": "470 uS/cm"}]
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -220,6 +220,14 @@ func (w *Watcher) PollEcoWitt(ctx context.Context, server string) {
 		dataMap["Aisle."+ch.Channel+".Humi"] = trimTrailingPercent(ch.Humidity)
 	}
 
+	for _, ch := range apiResponse.CHEc {
+		dataMap["SoilEC."+ch.Channel+".Moisture"] = trimTrailingPercent(ch.Humidity)
+		dataMap["SoilEC."+ch.Channel+".Temp"] = ch.Temp
+		if ec := ecToMilliSiemens(ch.EC); ec != "" {
+			dataMap["SoilEC."+ch.Channel+".EC"] = ec
+		}
+	}
+
 	for _, item := range apiResponse.CommonList {
 		meta, ok := types.ECWCommonSensors[types.NormalizeECWID(item.ID)]
 		if !ok {
@@ -406,6 +414,23 @@ func trimCommonVal(v string) string {
 		i++
 	}
 	return v[:i]
+}
+
+// ecToMilliSiemens converts a WH52 soil-EC reading to milliSiemens/cm. The
+// gateway reports EC in microSiemens/cm with the unit inline (e.g.
+// "470 uS/cm"), but EC is conventionally displayed in mS/cm, so the numeric
+// part is divided by 1000. Returns "" for dash placeholders or unparseable
+// input so the caller can skip storing a row.
+func ecToMilliSiemens(v string) string {
+	n := trimCommonVal(v)
+	if n == "" {
+		return ""
+	}
+	f, err := strconv.ParseFloat(n, 64)
+	if err != nil {
+		return ""
+	}
+	return strconv.FormatFloat(f/1000.0, 'f', -1, 64)
 }
 
 // computeZoneVPD calculates and stores derived VPD sensor readings for every

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -260,6 +260,35 @@ func TestPollEcoWitt_CHAisle(t *testing.T) {
 	assert.InDelta(t, 42.0, humi, 0.0001, "percent suffix must be trimmed")
 }
 
+func TestPollEcoWitt_CHEc(t *testing.T) {
+	t.Parallel()
+
+	db := testutil.NewTestDB(t)
+	server := fakes.FakeEcoWitt(t, "ch_ec")
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	moistID := seedSensor(t, db, "ecowitt", u.Host, "SoilEC.2.Moisture")
+	tempID := seedSensor(t, db, "ecowitt", u.Host, "SoilEC.2.Temp")
+	ecID := seedSensor(t, db, "ecowitt", u.Host, "SoilEC.2.EC")
+
+	w := newTestWatcher(t, db)
+	w.PollEcoWitt(context.Background(), u.Host)
+
+	for _, id := range []int{moistID, tempID, ecID} {
+		assert.Equalf(t, 1, countSensorData(t, db, id), "sensor %d should have one row", id)
+	}
+
+	var moist, temp, ec float64
+	require.NoError(t, db.QueryRow(`SELECT value FROM sensor_data WHERE sensor_id = $1`, moistID).Scan(&moist))
+	assert.InDelta(t, 28.0, moist, 0.0001, "soil moisture percent suffix must be trimmed")
+	require.NoError(t, db.QueryRow(`SELECT value FROM sensor_data WHERE sensor_id = $1`, tempID).Scan(&temp))
+	assert.InDelta(t, 78.1, temp, 0.0001)
+	require.NoError(t, db.QueryRow(`SELECT value FROM sensor_data WHERE sensor_id = $1`, ecID).Scan(&ec))
+	assert.InDelta(t, 0.47, ec, 0.0001, "EC must be converted from uS/cm to mS/cm")
+}
+
 func TestPollEcoWitt_CommonList(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
Adds support for the newly released EcoWitt **WH52** 2nd generation soil sensor, reported by the gateway in the `ch_ec` array (EcoWitt local API v1.0.6). The WH52 measures soil moisture, soil temperature, and electrical conductivity — unlike the moisture-only WH51 (`ch_soil`) that Isley already handles. Previously `ch_ec` was dropped on scan, so WH52 owners saw nothing register.

## How
- `model/types/ecowitt_models.go`: new `ECWCHEc` struct + `ch_ec` field on `ECWAPIResponse`.
- Scan (`handlers/sensors.go`) registers three sensors per channel, following the existing `ch_aisle` pattern: `SoilEC.<ch>.Moisture` (%), `SoilEC.<ch>.Temp` (°F/°C), `SoilEC.<ch>.EC` (mS/cm).
- Poll (`watcher/watcher.go`) ingests the same keys. EC is reported in µS/cm with the unit inline (e.g. `"470 uS/cm"`) and converted to mS/cm — the conventional display unit — in `ecToMilliSiemens`.
- Battery/voltage are parsed but not registered as sensors, matching `ch_soil`/`ch_aisle`.

## Mapping source
Confirmed against a live GW-series gateway payload, the `alexlenk/ecowitt_local` integration's `ch_ec` handling, and the WH52 spec (soil moisture / temp / EC 0–10,000 µS/cm).

## Tests
Adds `TestPollEcoWitt_CHEc` + `tests/fixtures/ecowitt/ch_ec.json`; `go test ./...` passes. Same approach as the previously-merged `ch_aisle`/`common_list` expansion (#176).

## Try it
A prebuilt image with this change (v2.2.0 + this commit) is available for testing:

    docker pull ghcr.io/evelinwa/isley:v2.2.0-wh52

Generated with [Claude Code](https://claude.com/claude-code)