### PR TITLE
Fix sensor delete failing when hourly-rollup data exists (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Deleting a sensor that had hourly-rollup data failed with "Failed to delete
+  sensor". `DeleteSensorByID` now purges `sensor_data_hourly` and
+  `rolling_averages` rows alongside `sensor_data` within a single transaction,
+  so the foreign key on `sensor_data_hourly` no longer blocks the delete
+  (#206).
 
 ### Security
 

--- a/handlers/sensors.go
+++ b/handlers/sensors.go
@@ -980,16 +980,37 @@ func DeleteSensor(c *gin.Context) {
 func DeleteSensorByID(db *sql.DB, id string) error {
 	fieldLogger := logger.Log.WithField("func", "DeleteSensorByID")
 
-	// Delete sensor_data for this sensor
-	_, err := db.Exec("DELETE FROM sensor_data WHERE sensor_id = $1", id)
+	// Delete the sensor and everything that references it in a single
+	// transaction. sensor_data_hourly and rolling_averages both carry a
+	// sensor_id referencing sensors(id) (the former with a FK and no
+	// ON DELETE CASCADE), so the final DELETE FROM sensors fails unless
+	// those rows are purged first. Wrapping the deletes in a transaction
+	// keeps the rows consistent if any single statement fails.
+	tx, err := db.Begin()
 	if err != nil {
-		fieldLogger.WithError(err).Error("Error deleting sensor data")
+		fieldLogger.WithError(err).Error("Error beginning delete transaction")
 		return err
 	}
+	defer tx.Rollback() //nolint:errcheck // no-op once the tx is committed
 
-	_, err = db.Exec("DELETE FROM sensors WHERE id = $1", id)
-	if err != nil {
-		fieldLogger.WithError(err).Error("Error deleting sensor")
+	stmts := []struct {
+		desc  string
+		query string
+	}{
+		{"sensor data", "DELETE FROM sensor_data WHERE sensor_id = $1"},
+		{"sensor hourly rollups", "DELETE FROM sensor_data_hourly WHERE sensor_id = $1"},
+		{"sensor rolling averages", "DELETE FROM rolling_averages WHERE sensor_id = $1"},
+		{"sensor", "DELETE FROM sensors WHERE id = $1"},
+	}
+	for _, s := range stmts {
+		if _, err := tx.Exec(s.query, id); err != nil {
+			fieldLogger.WithError(err).Errorf("Error deleting %s", s.desc)
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		fieldLogger.WithError(err).Error("Error committing sensor delete")
 		return err
 	}
 	return nil

--- a/handlers/sensors_db_test.go
+++ b/handlers/sensors_db_test.go
@@ -89,14 +89,24 @@ func TestDeleteSensorByID_CascadesSensorData(t *testing.T) {
 	testutil.MustExec(t, db, `INSERT INTO sensors (id, name, zone_id, source, device, type) VALUES (1, 'Doomed', 1, 'src', 'D', 'temp')`)
 	testutil.MustExec(t, db, `INSERT INTO sensor_data (sensor_id, value) VALUES (1, 1.0)`)
 	testutil.MustExec(t, db, `INSERT INTO sensor_data (sensor_id, value) VALUES (1, 2.0)`)
+	// sensor_data_hourly carries a FK to sensors(id) with no ON DELETE
+	// CASCADE; without purging it first the DELETE FROM sensors fails. This
+	// row is what makes the test exercise the #206 regression.
+	testutil.MustExec(t, db, `INSERT INTO sensor_data_hourly (sensor_id, bucket, min_val, max_val, avg_val, sample_count) VALUES (1, '2026-06-23 00:00:00', 1.0, 2.0, 1.5, 2)`)
+	// rolling_averages is populated automatically by the update_rolling_avg
+	// trigger on the sensor_data inserts above; assert it is purged too.
 
 	require.NoError(t, handlers.DeleteSensorByID(db, "1"))
 
-	var sensorCount, dataCount int
+	var sensorCount, dataCount, hourlyCount, rollingCount int
 	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM sensors WHERE id = 1`).Scan(&sensorCount))
 	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM sensor_data WHERE sensor_id = 1`).Scan(&dataCount))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM sensor_data_hourly WHERE sensor_id = 1`).Scan(&hourlyCount))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM rolling_averages WHERE sensor_id = 1`).Scan(&rollingCount))
 	assert.Zero(t, sensorCount)
 	assert.Zero(t, dataCount, "DeleteSensorByID must purge sensor_data rows for the sensor")
+	assert.Zero(t, hourlyCount, "DeleteSensorByID must purge sensor_data_hourly rows for the sensor")
+	assert.Zero(t, rollingCount, "DeleteSensorByID must purge rolling_averages rows for the sensor")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Fixes #206. `DELETE /sensors/delete/:id` returned "Failed to delete sensor" for any sensor that had hourly-rollup data.

## Root cause
`DeleteSensorByID` (`handlers/sensors.go`) deleted `sensor_data` and the `sensors` row, but never deleted `sensor_data_hourly`. Migration `015_sensor_data_hourly` defines `sensor_id` as a `FOREIGN KEY REFERENCES sensors(id)` with **no `ON DELETE CASCADE`**, so once a sensor had been downsampled (charts >24h populate this table) the final `DELETE FROM sensors` violated the FK and the whole delete failed. `rolling_averages` rows were also left orphaned (no FK, so not a blocker, but a leak).

## Fix
`DeleteSensorByID` now purges `sensor_data`, `sensor_data_hourly`, and `rolling_averages` for the sensor and then deletes the `sensors` row — all within a single transaction so a partial delete can't leave the tables inconsistent.

## Tests
`TestDeleteSensorByID_CascadesSensorData` previously passed only because it never inserted hourly rows. It now seeds a `sensor_data_hourly` row (and relies on the trigger-populated `rolling_averages` row) and asserts both are purged. Verified the test fails with `FOREIGN KEY constraint failed` on the pre-fix code and passes with the fix. `go build ./...`, `go vet`, and `go test ./handlers/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)